### PR TITLE
Improve perf on class / pet icons

### DIFF
--- a/Common/UnitInfoHelpers.lua
+++ b/Common/UnitInfoHelpers.lua
@@ -143,11 +143,7 @@ local refreshFrame = CreateFrame("Frame");
 refreshFrame:RegisterEvent(addon.PLAYER_ENTERING_WORLD);
 refreshFrame:RegisterEvent(addon.ARENA_PREP_OPPONENT_SPECIALIZATIONS);
 refreshFrame:SetScript("OnEvent", function (self, event)
-    addon.cachedBattlefieldSpec = {}; -- reset after every loading screen
-
-    -- Right after a loading screen, both UnitInBattleground and C_PvP.IsBattleground are false
-    -- we might as well have request frame always showing and scanning every 2.5s, request if in BG
-    -- instead of show/hide request frame based on UnitInBattleground / C_PvP.IsBattleground
+    addon.cachedBattlefieldSpec = {};
 end)
 
 addon.GetBattlefieldSpecByPlayerGuid = function (guid)

--- a/Core.lua
+++ b/Core.lua
@@ -787,21 +787,21 @@ function SweepyBoop:OnInitialize()
     -- Register callback (https://www.wowace.com/projects/ace3/pages/ace-db-3-0-tutorial)
     self.db.RegisterCallback(self, "OnProfileReset", "RefreshConfig");
 
-    -- Nameplate module needs optimization to eat less CPU
-    -- Setup nameplate modules
-    self:SetupNameplateModules();
+    -- -- Nameplate module needs optimization to eat less CPU
+    -- -- Setup nameplate modules
+    -- self:SetupNameplateModules();
 
-    -- Setup arena enemy cooldown icons
-    self:SetupOffensiveIcons();
-    self:SetupCooldownTrackingIcons();
+    -- -- Setup arena enemy cooldown icons
+    -- self:SetupOffensiveIcons();
+    -- self:SetupCooldownTrackingIcons();
 
-    self:SetupHealerIndicator();
+    -- self:SetupHealerIndicator();
 
-    -- Setup raid frame modules
-    self:SetupRaidFrameAggroHighlight();
-    self:SetupRaidFrameAuraModule();
+    -- -- Setup raid frame modules
+    -- self:SetupRaidFrameAggroHighlight();
+    -- self:SetupRaidFrameAuraModule();
 
-    self:SetupQueueReminder();
+    -- self:SetupQueueReminder();
 end
 
 function SweepyBoop:TestArena()

--- a/Core.lua
+++ b/Core.lua
@@ -791,17 +791,17 @@ function SweepyBoop:OnInitialize()
     -- Setup nameplate modules
     self:SetupNameplateModules();
 
-    -- Setup arena enemy cooldown icons
-    self:SetupOffensiveIcons();
-    self:SetupCooldownTrackingIcons();
+    -- -- Setup arena enemy cooldown icons
+    -- self:SetupOffensiveIcons();
+    -- self:SetupCooldownTrackingIcons();
 
-    self:SetupHealerIndicator();
+    -- self:SetupHealerIndicator();
 
-    -- Setup raid frame modules
-    self:SetupRaidFrameAggroHighlight();
-    self:SetupRaidFrameAuraModule();
+    -- -- Setup raid frame modules
+    -- self:SetupRaidFrameAggroHighlight();
+    -- self:SetupRaidFrameAuraModule();
 
-    self:SetupQueueReminder();
+    -- self:SetupQueueReminder();
 end
 
 function SweepyBoop:TestArena()

--- a/Core.lua
+++ b/Core.lua
@@ -787,21 +787,21 @@ function SweepyBoop:OnInitialize()
     -- Register callback (https://www.wowace.com/projects/ace3/pages/ace-db-3-0-tutorial)
     self.db.RegisterCallback(self, "OnProfileReset", "RefreshConfig");
 
-    -- -- Nameplate module needs optimization to eat less CPU
-    -- -- Setup nameplate modules
-    -- self:SetupNameplateModules();
+    -- Nameplate module needs optimization to eat less CPU
+    -- Setup nameplate modules
+    self:SetupNameplateModules();
 
-    -- -- Setup arena enemy cooldown icons
-    -- self:SetupOffensiveIcons();
-    -- self:SetupCooldownTrackingIcons();
+    -- Setup arena enemy cooldown icons
+    self:SetupOffensiveIcons();
+    self:SetupCooldownTrackingIcons();
 
-    -- self:SetupHealerIndicator();
+    self:SetupHealerIndicator();
 
-    -- -- Setup raid frame modules
-    -- self:SetupRaidFrameAggroHighlight();
-    -- self:SetupRaidFrameAuraModule();
+    -- Setup raid frame modules
+    self:SetupRaidFrameAggroHighlight();
+    self:SetupRaidFrameAuraModule();
 
-    -- self:SetupQueueReminder();
+    self:SetupQueueReminder();
 end
 
 function SweepyBoop:TestArena()

--- a/Core.lua
+++ b/Core.lua
@@ -791,17 +791,17 @@ function SweepyBoop:OnInitialize()
     -- Setup nameplate modules
     self:SetupNameplateModules();
 
-    -- -- Setup arena enemy cooldown icons
-    -- self:SetupOffensiveIcons();
-    -- self:SetupCooldownTrackingIcons();
+    -- Setup arena enemy cooldown icons
+    self:SetupOffensiveIcons();
+    self:SetupCooldownTrackingIcons();
 
-    -- self:SetupHealerIndicator();
+    self:SetupHealerIndicator();
 
-    -- -- Setup raid frame modules
-    -- self:SetupRaidFrameAggroHighlight();
-    -- self:SetupRaidFrameAuraModule();
+    -- Setup raid frame modules
+    self:SetupRaidFrameAggroHighlight();
+    self:SetupRaidFrameAuraModule();
 
-    -- self:SetupQueueReminder();
+    self:SetupQueueReminder();
 end
 
 function SweepyBoop:TestArena()

--- a/Internal/HideHotKeys.lua
+++ b/Internal/HideHotKeys.lua
@@ -94,4 +94,5 @@ local frame = CreateFrame("Frame");
 frame:RegisterEvent(addon.PLAYER_ENTERING_WORLD);
 frame:SetScript("OnEvent", function ()
     HideHotKeys();
+    CompactPartyFrame:SetScale(1.1);
 end)

--- a/Nameplates/ClassIcons.lua
+++ b/Nameplates/ClassIcons.lua
@@ -54,42 +54,6 @@ local function GetIconOptions(class, pvpClassification, roleAssigned)
     return iconID, iconCoords, scaleFactor;
 end
 
-addon.ShowClassIcon = function (nameplate)
-    if ( not nameplate.classIconContainer ) then return end
-    local classIconContainer = nameplate.classIconContainer;
-
-    local style = SweepyBoop.db.profile.nameplatesFriendly.classIconStyle;
-    if classIconContainer.FriendlyClassIcon then
-        classIconContainer.FriendlyClassIcon:SetShown(style == addon.CLASS_ICON_STYLE.ICON or classIconContainer.isSpecialIcon);
-    end
-    if classIconContainer.FriendlyClassArrow then
-        classIconContainer.FriendlyClassArrow:SetShown(style == addon.CLASS_ICON_STYLE.ARROW and ( not classIconContainer.isSpecialIcon ));
-    end
-end
-
-addon.HideClassIcon = function(nameplate)
-    if ( not nameplate.classIconContainer ) then return end
-
-    if nameplate.classIconContainer.FriendlyClassIcon then
-        nameplate.classIconContainer.FriendlyClassIcon:Hide();
-    end
-    if nameplate.classIconContainer.FriendlyClassArrow then
-        nameplate.classIconContainer.FriendlyClassArrow:Hide();
-    end
-end
-
-addon.UpdateClassIconTargetHighlight = function (nameplate, frame)
-    local isTarget = UnitIsUnit(frame.unit, "target");
-    if nameplate.classIconContainer then
-        if nameplate.classIconContainer.FriendlyClassIcon then
-            nameplate.classIconContainer.FriendlyClassIcon.targetHighlight:SetShown(isTarget);
-        end
-        if nameplate.classIconContainer.FriendlyClassArrow then
-            nameplate.classIconContainer.FriendlyClassArrow.targetHighlight:SetShown(isTarget);
-        end
-    end
-end
-
 -- For FC icon, listen to whatever triggers CompactUnitFrame_UpdatePvPClassificationIndicator
 addon.UpdateClassIcon = function(nameplate, frame)
     -- Full update if class, PvPClassification, roleAssigned or configurations have changed
@@ -140,4 +104,41 @@ addon.UpdateClassIcon = function(nameplate, frame)
     end
 
     addon.UpdateClassIconTargetHighlight(nameplate, frame);
+end
+
+addon.ShowClassIcon = function (nameplate, frame)
+    addon.UpdateClassIcon(nameplate, frame);
+    if ( not nameplate.classIconContainer ) then return end
+    local classIconContainer = nameplate.classIconContainer;
+
+    local style = SweepyBoop.db.profile.nameplatesFriendly.classIconStyle;
+    if classIconContainer.FriendlyClassIcon then
+        classIconContainer.FriendlyClassIcon:SetShown(style == addon.CLASS_ICON_STYLE.ICON or classIconContainer.isSpecialIcon);
+    end
+    if classIconContainer.FriendlyClassArrow then
+        classIconContainer.FriendlyClassArrow:SetShown(style == addon.CLASS_ICON_STYLE.ARROW and ( not classIconContainer.isSpecialIcon ));
+    end
+end
+
+addon.HideClassIcon = function(nameplate)
+    if ( not nameplate.classIconContainer ) then return end
+
+    if nameplate.classIconContainer.FriendlyClassIcon then
+        nameplate.classIconContainer.FriendlyClassIcon:Hide();
+    end
+    if nameplate.classIconContainer.FriendlyClassArrow then
+        nameplate.classIconContainer.FriendlyClassArrow:Hide();
+    end
+end
+
+addon.UpdateClassIconTargetHighlight = function (nameplate, frame)
+    local isTarget = UnitIsUnit(frame.unit, "target");
+    if nameplate.classIconContainer then
+        if nameplate.classIconContainer.FriendlyClassIcon then
+            nameplate.classIconContainer.FriendlyClassIcon.targetHighlight:SetShown(isTarget);
+        end
+        if nameplate.classIconContainer.FriendlyClassArrow then
+            nameplate.classIconContainer.FriendlyClassArrow.targetHighlight:SetShown(isTarget);
+        end
+    end
 end

--- a/Nameplates/ClassIcons.lua
+++ b/Nameplates/ClassIcons.lua
@@ -62,7 +62,10 @@ end
 
 -- For FC icon, listen to whatever triggers CompactUnitFrame_UpdatePvPClassificationIndicator
 addon.UpdateClassIcon = function(nameplate, frame)
-    if ( not nameplate.classIconContainer ) then return end -- Only update if visible
+    -- Only update if already created
+    if ( not nameplate.classIconContainer ) then return end
+    local classIconContainer = nameplate.classIconContainer;
+    if ( not classIconContainer.FriendlyClassIcon ) or ( not classIconContainer.FriendlyClassArrow ) then return end
 
     -- Full update if class, PvPClassification, roleAssigned or configurations have changed
     -- (healer icons work between solo shuffle rounds because UnitGroupRolesAssigned works on opponent healer as well)
@@ -71,13 +74,10 @@ addon.UpdateClassIcon = function(nameplate, frame)
     local pvpClassification = UnitPvpClassification(frame.unit);
     local roleAssigned = UnitGroupRolesAssigned(frame.unit);
     local lastModifiedFriendly = SweepyBoop.db.profile.nameplatesFriendly.lastModified;
-    nameplate.classIconContainer = nameplate.classIconContainer or {};
-    local iconFrame = EnsureIcon(nameplate);
-    local arrowFrame = EnsureArrow(nameplate);
-    if ( not iconFrame ) or ( not arrowFrame ) then return end
-    local classIconContainer = nameplate.classIconContainer;
     if ( classIconContainer.class ~= class ) or ( classIconContainer.pvpClassification ~= pvpClassification ) or ( classIconContainer.roleAssigned ~= roleAssigned ) or ( classIconContainer.lastModifiedFriendly ~= lastModifiedFriendly ) then
         local iconID, iconCoords, isSpecialIcon = GetIconOptions(class, pvpClassification, roleAssigned);
+        local iconFrame = classIconContainer.FriendlyClassIcon;
+        local arrowFrame = classIconContainer.FriendlyClassArrow;
 
         if ( not iconID ) then
             iconFrame.icon:SetAlpha(0);

--- a/Nameplates/ClassIcons.lua
+++ b/Nameplates/ClassIcons.lua
@@ -1,6 +1,7 @@
 local _, addon = ...;
 
 local PvPUnitClassification = Enum.PvPUnitClassification;
+local specialIconScaleFactor = 1.25;
 
 local flagCarrierIcons = {
     [PvPUnitClassification.FlagCarrierHorde] = addon.ICON_ID_FLAG_CARRIER_HORDE,
@@ -42,14 +43,14 @@ local function GetIconOptions(class, pvpClassification, roleAssigned)
         else
             iconID = addon.ICON_ID_HEALER;
             iconCoords = addon.ICON_COORDS_HEALER;
-            scaleFactor = 1.25;
+            scaleFactor = specialIconScaleFactor;
         end
     end
 
     if ( flagCarrierIcons[pvpClassification] ) and config.useFlagCarrierIcon then
         iconID = flagCarrierIcons[pvpClassification];
         iconCoords = {0, 1, 0, 1};
-        scaleFactor = 1.25;
+        scaleFactor = specialIconScaleFactor;
     end
 
     return iconID, iconCoords, scaleFactor;
@@ -57,13 +58,14 @@ end
 
 addon.ShowClassIcon = function (nameplate)
     if ( not nameplate.classIconContainer ) then return end
+    local classIconContainer = nameplate.classIconContainer;
 
     local style = SweepyBoop.db.profile.nameplatesFriendly.classIconStyle;
-    if nameplate.classIconContainer.FriendlyClassIcon then
-        nameplate.classIconContainer.FriendlyClassIcon:SetShown(style == addon.CLASS_ICON_STYLE.ICON);
+    if classIconContainer.FriendlyClassIcon then
+        classIconContainer.FriendlyClassIcon:SetShown(style == addon.CLASS_ICON_STYLE.ICON or classIconContainer.isSpecialIcon);
     end
-    if nameplate.classIconContainer.FriendlyClassArrow then
-        nameplate.classIconContainer.FriendlyClassArrow:SetShown(style == addon.CLASS_ICON_STYLE.ARROW);
+    if classIconContainer.FriendlyClassArrow then
+        classIconContainer.FriendlyClassArrow:SetShown(style == addon.CLASS_ICON_STYLE.ARROW and ( not classIconContainer.isSpecialIcon ));
     end
 end
 
@@ -129,6 +131,8 @@ addon.UpdateClassIcon = function(nameplate, frame)
             arrowFrame:SetScale(SweepyBoop.db.profile.nameplatesFriendly.classIconScale / 100);
             arrowFrame:SetPoint("CENTER", arrowFrame:GetParent(), "CENTER", 0, SweepyBoop.db.profile.nameplatesFriendly.classIconOffset);
         end
+
+        classIconContainer.isSpecialIcon = ( scaleFactor == specialIconScaleFactor );
 
         classIconContainer.class = class;
         classIconContainer.pvpClassification = pvpClassification;

--- a/Nameplates/ClassIcons.lua
+++ b/Nameplates/ClassIcons.lua
@@ -135,13 +135,14 @@ end
 
 addon.HideClassIcon = function(nameplate)
     if ( not nameplate.classIconContainer ) then return end
+    local classIconContainer = nameplate.classIconContainer;
 
-    if nameplate.classIconContainer.FriendlyClassIcon then
-        nameplate.classIconContainer.FriendlyClassIcon:Hide();
+    if classIconContainer.FriendlyClassIcon then
+        classIconContainer.FriendlyClassIcon:Hide();
     end
-    if nameplate.classIconContainer.FriendlyClassArrow then
-        nameplate.classIconContainer.FriendlyClassArrow:Hide();
+    if classIconContainer.FriendlyClassArrow then
+        classIconContainer.FriendlyClassArrow:Hide();
     end
 
-    PvPUnitClassification.isShown = false;
+    classIconContainer.isShown = false;
 end

--- a/Nameplates/ClassIcons.lua
+++ b/Nameplates/ClassIcons.lua
@@ -37,9 +37,13 @@ local function GetIconOptions(class, pvpClassification, roleAssigned)
     iconCoords = CLASS_ICON_TCOORDS[class];
 
     if ( roleAssigned == "HEALER" ) and config.useHealerIcon then
-        iconID = addon.ICON_ID_HEALER;
-        iconCoords = addon.ICON_COORDS_HEALER;
-        scaleFactor = 1.25;
+        if config.showHealerOnly then -- can be overwritten by flag carrier
+            iconID = nil;
+        else
+            iconID = addon.ICON_ID_HEALER;
+            iconCoords = addon.ICON_COORDS_HEALER;
+            scaleFactor = 1.25;
+        end
     end
 
     if ( flagCarrierIcons[pvpClassification] ) and config.useFlagCarrierIcon then

--- a/Nameplates/ClassIcons.lua
+++ b/Nameplates/ClassIcons.lua
@@ -30,7 +30,7 @@ end
 local function GetIconOptions(class, pvpClassification, roleAssigned)
     local iconID;
     local iconCoords = {0, 1, 0, 1};
-    local scaleFactor = 1; -- 1.25 for healers and flag carriers
+    local isSpecialIcon;
 
     local config = SweepyBoop.db.profile.nameplatesFriendly;
     -- Check regular class, then healer, then flag carrier; latter overwrites the former
@@ -40,7 +40,7 @@ local function GetIconOptions(class, pvpClassification, roleAssigned)
     if ( roleAssigned == "HEALER" ) and config.useHealerIcon then
         iconID = addon.ICON_ID_HEALER;
         iconCoords = addon.ICON_COORDS_HEALER;
-        scaleFactor = specialIconScaleFactor;
+        isSpecialIcon = true;
     elseif ( roleAssigned ~= "HEALER" ) and config.showHealerOnly then
         iconID = nil;
     end
@@ -48,7 +48,7 @@ local function GetIconOptions(class, pvpClassification, roleAssigned)
     if ( flagCarrierIcons[pvpClassification] ) and config.useFlagCarrierIcon then
         iconID = flagCarrierIcons[pvpClassification];
         iconCoords = {0, 1, 0, 1};
-        scaleFactor = specialIconScaleFactor;
+        isSpecialIcon = true;
     end
 
     return iconID, iconCoords, scaleFactor;
@@ -105,7 +105,7 @@ addon.UpdateClassIcon = function(nameplate, frame)
     if ( not iconFrame ) or ( not arrowFrame ) then return end
     local classIconContainer = nameplate.classIconContainer;
     if ( classIconContainer.class ~= class ) or ( classIconContainer.pvpClassification ~= pvpClassification ) or ( classIconContainer.roleAssigned ~= roleAssigned ) or ( classIconContainer.lastModifiedFriendly ~= lastModifiedFriendly ) then
-        local iconID, iconCoords, scaleFactor = GetIconOptions(class, pvpClassification, roleAssigned);
+        local iconID, iconCoords, isSpecialIcon = GetIconOptions(class, pvpClassification, roleAssigned);
 
         if ( not iconID ) then
             iconFrame.icon:SetAlpha(0);
@@ -119,6 +119,7 @@ addon.UpdateClassIcon = function(nameplate, frame)
             iconFrame.targetHighlight:SetAlpha(1);
             iconFrame.icon:SetTexture(iconID);
             iconFrame.icon:SetTexCoord(unpack(iconCoords));
+            local scaleFactor = ( isSpecialIcon and specialIconScaleFactor ) or 1;
             iconFrame:SetScale(SweepyBoop.db.profile.nameplatesFriendly.classIconScale / 100 * scaleFactor);
             iconFrame:SetPoint("CENTER", iconFrame:GetParent(), "CENTER", 0, SweepyBoop.db.profile.nameplatesFriendly.classIconOffset);
 
@@ -130,7 +131,7 @@ addon.UpdateClassIcon = function(nameplate, frame)
             arrowFrame:SetPoint("CENTER", arrowFrame:GetParent(), "CENTER", 0, SweepyBoop.db.profile.nameplatesFriendly.classIconOffset);
         end
 
-        classIconContainer.isSpecialIcon = ( scaleFactor == specialIconScaleFactor );
+        classIconContainer.isSpecialIcon = isSpecialIcon;
 
         classIconContainer.class = class;
         classIconContainer.pvpClassification = pvpClassification;

--- a/Nameplates/ClassIcons.lua
+++ b/Nameplates/ClassIcons.lua
@@ -9,7 +9,7 @@ local flagCarrierIcons = {
     [PvPUnitClassification.FlagCarrierNeutral] = addon.ICON_ID_FLAG_CARRIER_NEUTRAL,
 };
 
-local function EnsureIconAndArrow(nameplate)
+local function EnsureClassIcon(nameplate)
     nameplate.classIconContainer = nameplate.classIconContainer or {};
     if ( not nameplate.classIconContainer.FriendlyClassIcon ) then
         nameplate.classIconContainer.FriendlyClassIcon = addon.CreateClassOrSpecIcon(nameplate, "CENTER", "CENTER", true);
@@ -61,11 +61,13 @@ addon.UpdateClassIconTargetHighlight = function (nameplate, frame)
 end
 
 -- For FC icon, listen to whatever triggers CompactUnitFrame_UpdatePvPClassificationIndicator
-addon.UpdateClassIcon = function(nameplate, frame)
-    -- Only update if already created
+addon.UpdateClassIcon = function(nameplate, frame, forceUpdate)
     if ( not nameplate.classIconContainer ) then return end
     local classIconContainer = nameplate.classIconContainer;
     if ( not classIconContainer.FriendlyClassIcon ) or ( not classIconContainer.FriendlyClassArrow ) then return end
+
+    -- Only update if visible or forceUpdate (on first show)
+    if ( not classIconContainer.isShown ) and ( not forceUpdate ) then return end
 
     -- Full update if class, PvPClassification, roleAssigned or configurations have changed
     -- (healer icons work between solo shuffle rounds because UnitGroupRolesAssigned works on opponent healer as well)
@@ -115,8 +117,8 @@ addon.UpdateClassIcon = function(nameplate, frame)
 end
 
 addon.ShowClassIcon = function (nameplate, frame)
-    EnsureIconAndArrow(nameplate);
-    addon.UpdateClassIcon(nameplate, frame);
+    EnsureClassIcon(nameplate);
+    addon.UpdateClassIcon(nameplate, frame, true);
     if ( not nameplate.classIconContainer ) then return end
     local classIconContainer = nameplate.classIconContainer;
 
@@ -127,6 +129,8 @@ addon.ShowClassIcon = function (nameplate, frame)
     if classIconContainer.FriendlyClassArrow then
         classIconContainer.FriendlyClassArrow:SetShown(style == addon.CLASS_ICON_STYLE.ARROW and ( not classIconContainer.isSpecialIcon ));
     end
+
+    classIconContainer.isShown = true;
 end
 
 addon.HideClassIcon = function(nameplate)
@@ -138,4 +142,6 @@ addon.HideClassIcon = function(nameplate)
     if nameplate.classIconContainer.FriendlyClassArrow then
         nameplate.classIconContainer.FriendlyClassArrow:Hide();
     end
+
+    PvPUnitClassification.isShown = false;
 end

--- a/Nameplates/ClassIcons.lua
+++ b/Nameplates/ClassIcons.lua
@@ -54,6 +54,18 @@ local function GetIconOptions(class, pvpClassification, roleAssigned)
     return iconID, iconCoords, scaleFactor;
 end
 
+addon.UpdateClassIconTargetHighlight = function (nameplate, frame)
+    local isTarget = UnitIsUnit(frame.unit, "target");
+    if nameplate.classIconContainer then
+        if nameplate.classIconContainer.FriendlyClassIcon then
+            nameplate.classIconContainer.FriendlyClassIcon.targetHighlight:SetShown(isTarget);
+        end
+        if nameplate.classIconContainer.FriendlyClassArrow then
+            nameplate.classIconContainer.FriendlyClassArrow.targetHighlight:SetShown(isTarget);
+        end
+    end
+end
+
 -- For FC icon, listen to whatever triggers CompactUnitFrame_UpdatePvPClassificationIndicator
 addon.UpdateClassIcon = function(nameplate, frame)
     -- Full update if class, PvPClassification, roleAssigned or configurations have changed
@@ -128,17 +140,5 @@ addon.HideClassIcon = function(nameplate)
     end
     if nameplate.classIconContainer.FriendlyClassArrow then
         nameplate.classIconContainer.FriendlyClassArrow:Hide();
-    end
-end
-
-addon.UpdateClassIconTargetHighlight = function (nameplate, frame)
-    local isTarget = UnitIsUnit(frame.unit, "target");
-    if nameplate.classIconContainer then
-        if nameplate.classIconContainer.FriendlyClassIcon then
-            nameplate.classIconContainer.FriendlyClassIcon.targetHighlight:SetShown(isTarget);
-        end
-        if nameplate.classIconContainer.FriendlyClassArrow then
-            nameplate.classIconContainer.FriendlyClassArrow.targetHighlight:SetShown(isTarget);
-        end
     end
 end

--- a/Nameplates/ClassIcons.lua
+++ b/Nameplates/ClassIcons.lua
@@ -31,11 +31,12 @@ local function GetIconOptions(class, pvpClassification, roleAssigned)
     iconID = addon.ICON_ID_CLASSES;
     iconCoords = CLASS_ICON_TCOORDS[class];
 
-    if ( roleAssigned == "HEALER" ) and config.useHealerIcon then
+    local isHealer = ( roleAssigned == "HEALER" );
+    if isHealer and config.useHealerIcon then
         iconID = addon.ICON_ID_HEALER;
         iconCoords = addon.ICON_COORDS_HEALER;
         isSpecialIcon = true;
-    elseif ( roleAssigned ~= "HEALER" ) and config.showHealerOnly then
+    elseif ( not isHealer ) and config.showHealerOnly then
         iconID = nil;
     end
 

--- a/Nameplates/ClassIcons.lua
+++ b/Nameplates/ClassIcons.lua
@@ -79,7 +79,7 @@ addon.UpdateClassIcon = function(nameplate, frame)
         local iconFrame = classIconContainer.FriendlyClassIcon;
         local arrowFrame = classIconContainer.FriendlyClassArrow;
 
-        if ( not iconID ) then
+        if ( not iconID ) then -- nil icon ID due to "Show Healer Only" option
             iconFrame.icon:SetAlpha(0);
             iconFrame.border:SetAlpha(0);
             iconFrame.targetHighlight:SetAlpha(0);

--- a/Nameplates/ClassIcons.lua
+++ b/Nameplates/ClassIcons.lua
@@ -39,7 +39,7 @@ local function GetIconOptions(class, pvpClassification, roleAssigned)
         iconID = nil;
     end
 
-    if ( flagCarrierIcons[pvpClassification] ) and config.useFlagCarrierIcon then
+    if ( pvpClassification ~= nil ) and ( flagCarrierIcons[pvpClassification] ) and config.useFlagCarrierIcon then
         iconID = flagCarrierIcons[pvpClassification];
         iconCoords = {0, 1, 0, 1};
         isSpecialIcon = true;

--- a/Nameplates/ClassIcons.lua
+++ b/Nameplates/ClassIcons.lua
@@ -9,22 +9,16 @@ local flagCarrierIcons = {
     [PvPUnitClassification.FlagCarrierNeutral] = addon.ICON_ID_FLAG_CARRIER_NEUTRAL,
 };
 
-local function EnsureIcon(nameplate)
+local function EnsureIconAndArrow(nameplate)
+    nameplate.classIconContainer = nameplate.classIconContainer or {};
     if ( not nameplate.classIconContainer.FriendlyClassIcon ) then
         nameplate.classIconContainer.FriendlyClassIcon = addon.CreateClassOrSpecIcon(nameplate, "CENTER", "CENTER", true);
         nameplate.classIconContainer.FriendlyClassIcon:Hide();
     end
-
-    return nameplate.classIconContainer.FriendlyClassIcon;
-end
-
-local function EnsureArrow(nameplate)
     if ( not nameplate.classIconContainer.FriendlyClassArrow ) then
         nameplate.classIconContainer.FriendlyClassArrow = addon.CreateClassColorArrowFrame(nameplate);
         nameplate.classIconContainer.FriendlyClassArrow:Hide();
     end
-
-    return nameplate.classIconContainer.FriendlyClassArrow;
 end
 
 local function GetIconOptions(class, pvpClassification, roleAssigned)
@@ -51,7 +45,7 @@ local function GetIconOptions(class, pvpClassification, roleAssigned)
         isSpecialIcon = true;
     end
 
-    return iconID, iconCoords, scaleFactor;
+    return iconID, iconCoords, isSpecialIcon;
 end
 
 addon.UpdateClassIconTargetHighlight = function (nameplate, frame)
@@ -68,6 +62,8 @@ end
 
 -- For FC icon, listen to whatever triggers CompactUnitFrame_UpdatePvPClassificationIndicator
 addon.UpdateClassIcon = function(nameplate, frame)
+    if ( not nameplate.classIconContainer ) then return end -- Only update if visible
+
     -- Full update if class, PvPClassification, roleAssigned or configurations have changed
     -- (healer icons work between solo shuffle rounds because UnitGroupRolesAssigned works on opponent healer as well)
     -- Always update visibility and target highlight, since CompactUnitFrame_UpdateName is called on every target change
@@ -119,6 +115,7 @@ addon.UpdateClassIcon = function(nameplate, frame)
 end
 
 addon.ShowClassIcon = function (nameplate, frame)
+    EnsureIconAndArrow(nameplate);
     addon.UpdateClassIcon(nameplate, frame);
     if ( not nameplate.classIconContainer ) then return end
     local classIconContainer = nameplate.classIconContainer;

--- a/Nameplates/ClassIcons.lua
+++ b/Nameplates/ClassIcons.lua
@@ -2,16 +2,10 @@ local _, addon = ...;
 
 local PvPUnitClassification = Enum.PvPUnitClassification;
 
-local flagCarrierClassNames = {
-    [PvPUnitClassification.FlagCarrierHorde] = "FlagCarrierHorde",
-    [PvPUnitClassification.FlagCarrierAlliance] = "FlagCarrierAlliance",
-    [PvPUnitClassification.FlagCarrierNeutral] = "FlagCarrierNeutral",
-};
-
 local flagCarrierIcons = {
-    ["FlagCarrierHorde"] = addon.ICON_ID_FLAG_CARRIER_HORDE,
-    ["FlagCarrierAlliance"] = addon.ICON_ID_FLAG_CARRIER_ALLIANCE,
-    ["FlagCarrierNeutral"] = addon.ICON_ID_FLAG_CARRIER_NEUTRAL,
+    [PvPUnitClassification.FlagCarrierHorde] = addon.ICON_ID_FLAG_CARRIER_HORDE,
+    [PvPUnitClassification.FlagCarrierAlliance] = addon.ICON_ID_FLAG_CARRIER_ALLIANCE,
+    [PvPUnitClassification.FlagCarrierNeutral] = addon.ICON_ID_FLAG_CARRIER_NEUTRAL,
 };
 
 local function EnsureIcon(nameplate)
@@ -32,23 +26,29 @@ local function EnsureArrow(nameplate)
     return nameplate.classIconContainer.FriendlyClassArrow;
 end
 
-local function GetIconOptions(class)
+local function GetIconOptions(class, pvpClassification, roleAssigned)
     local iconID;
     local iconCoords = {0, 1, 0, 1};
+    local scaleFactor = 1; -- 1.25 for healers and flag carriers
 
-    if ( flagCarrierIcons[class] ) then
-        iconID = flagCarrierIcons[class];
-    elseif ( class == "HEALER" ) then
+    local config = SweepyBoop.db.profile.nameplatesFriendly;
+    -- Check regular class, then healer, then flag carrier; latter overwrites the former
+    iconID = addon.ICON_ID_CLASSES;
+    iconCoords = CLASS_ICON_TCOORDS[class];
+
+    if ( roleAssigned == "HEALER" ) and config.useHealerIcon then
         iconID = addon.ICON_ID_HEALER;
         iconCoords = addon.ICON_COORDS_HEALER;
-    elseif ( class == "PET" ) then
-        iconID = addon.ICON_ID_PET;
-    else -- For regular classes
-        iconID = addon.ICON_ID_CLASSES;
-        iconCoords = CLASS_ICON_TCOORDS[class];
+        scaleFactor = 1.25;
     end
 
-    return iconID, iconCoords;
+    if ( flagCarrierIcons[pvpClassification] ) and config.useFlagCarrierIcon then
+        iconID = flagCarrierIcons[pvpClassification];
+        iconCoords = {0, 1, 0, 1};
+        scaleFactor = 1.25;
+    end
+
+    return iconID, iconCoords, scaleFactor;
 end
 
 addon.ShowClassIcon = function (nameplate)
@@ -74,7 +74,7 @@ addon.HideClassIcon = function(nameplate)
     end
 end
 
-addon.UpdateTargetHighlight = function (nameplate, frame)
+addon.UpdateClassIconTargetHighlight = function (nameplate, frame)
     local isTarget = UnitIsUnit(frame.unit, "target");
     if nameplate.classIconContainer then
         if nameplate.classIconContainer.FriendlyClassIcon then
@@ -86,55 +86,24 @@ addon.UpdateTargetHighlight = function (nameplate, frame)
     end
 end
 
-local specialClasses = { -- For these special classes, there is no arrow style
-    ["HEALER"] = true,
-    ["PET"] = true,
-    ["FlagCarrierHorde"] = true,
-    ["FlagCarrierAlliance"] = true,
-    ['FlagCarrierNeutral'] = true,
-};
-
 -- For FC icon, listen to whatever triggers CompactUnitFrame_UpdatePvPClassificationIndicator
 addon.UpdateClassIcon = function(nameplate, frame)
-    -- Full update if UnitGUID, PvPClassification, or configurations have changed
+    -- Full update if class, PvPClassification, roleAssigned or configurations have changed
     -- (healer icons work between solo shuffle rounds because UnitGroupRolesAssigned works on opponent healer as well)
     -- Always update visibility and target highlight, since CompactUnitFrame_UpdateName is called on every target change
-    local unitGUID = UnitGUID(frame.unit);
+    local class = addon.GetUnitClass(frame.unit);
     local pvpClassification = UnitPvpClassification(frame.unit);
+    local roleAssigned = UnitGroupRolesAssigned(frame.unit);
     local lastModifiedFriendly = SweepyBoop.db.profile.nameplatesFriendly.lastModified;
     nameplate.classIconContainer = nameplate.classIconContainer or {};
     local iconFrame = EnsureIcon(nameplate);
     local arrowFrame = EnsureArrow(nameplate);
     if ( not iconFrame ) or ( not arrowFrame ) then return end
     local classIconContainer = nameplate.classIconContainer;
-    if ( classIconContainer.currentGUID ~= unitGUID ) or ( classIconContainer.pvpClassification ~= pvpClassification ) or ( classIconContainer.lastModifiedFriendly ~= lastModifiedFriendly ) then
-        local isPlayer = UnitIsPlayer(frame.unit);
-        local class = ( isPlayer and addon.GetUnitClass(frame.unit) ) or "PET";
+    if ( classIconContainer.class ~= class ) or ( classIconContainer.pvpClassification ~= pvpClassification ) or ( classIconContainer.roleAssigned ~= roleAssigned ) or ( classIconContainer.lastModifiedFriendly ~= lastModifiedFriendly ) then
+        local iconID, iconCoords, scaleFactor = GetIconOptions(class, pvpClassification, roleAssigned);
 
-        -- Show dedicated healer icon
-        if SweepyBoop.db.profile.nameplatesFriendly.useHealerIcon then
-            -- For player nameplates, check if it's a healer
-            if isPlayer and ( UnitGroupRolesAssigned(frame.unit) == "HEALER" ) then
-                class = "HEALER";
-            end
-        end
-
-        -- Show dedicated flag carrier icon (this overwrites the healer icon)
-        -- Issue: flag carrier icons are showing up but no target highlight
-        if SweepyBoop.db.profile.nameplatesFriendly.useFlagCarrierIcon and isPlayer then
-            if pvpClassification and flagCarrierClassNames[pvpClassification] then
-                class = flagCarrierClassNames[pvpClassification];
-            end
-        end
-
-        -- If the player enabled "Show healers only", hide the icon except for flag carrier
-        if SweepyBoop.db.profile.nameplatesFriendly.showHealerOnly then
-            if ( class ~= "HEALER" and ( not flagCarrierIcons[class] ) ) then
-                class = "NONE"; -- To set alpha to 0
-            end
-        end
-
-        if ( class == "NONE" ) then
+        if ( not iconID ) then
             iconFrame.icon:SetAlpha(0);
             iconFrame.border:SetAlpha(0);
             iconFrame.targetHighlight:SetAlpha(0);
@@ -144,42 +113,24 @@ addon.UpdateClassIcon = function(nameplate, frame)
             iconFrame.icon:SetAlpha(1);
             iconFrame.border:SetAlpha(1);
             iconFrame.targetHighlight:SetAlpha(1);
-            local iconID, iconCoords = GetIconOptions(class);
             iconFrame.icon:SetTexture(iconID);
             iconFrame.icon:SetTexCoord(unpack(iconCoords));
-            local scale = SweepyBoop.db.profile.nameplatesFriendly.classIconScale / 100;
-            if ( class == "HEALER" ) then
-                scale = scale * 1.25; -- Because healer uses icon coords from a collection of icons, using the same scale would make it seem smaller
-            elseif ( class == "PET" ) then
-                scale = scale * 0.8; -- smaller icon for pets
-            end
-            iconFrame:SetScale(scale);
+            iconFrame:SetScale(SweepyBoop.db.profile.nameplatesFriendly.classIconScale / 100 * scaleFactor);
             iconFrame:SetPoint("CENTER", iconFrame:GetParent(), "CENTER", 0, SweepyBoop.db.profile.nameplatesFriendly.classIconOffset);
 
             local classColor = RAID_CLASS_COLORS[class];
-            if classColor then
-                arrowFrame.icon:SetAlpha(1);
-                arrowFrame.targetHighlight:SetAlpha(1);
-                arrowFrame.icon:SetVertexColor(classColor.r, classColor.g, classColor.b);
-            else
-                arrowFrame.icon:SetAlpha(0);
-                arrowFrame.targetHighlight:SetAlpha(0);
-            end
+            arrowFrame.icon:SetAlpha(1);
+            arrowFrame.targetHighlight:SetAlpha(1);
+            arrowFrame.icon:SetVertexColor(classColor.r, classColor.g, classColor.b);
             arrowFrame:SetScale(SweepyBoop.db.profile.nameplatesFriendly.classIconScale / 100);
             arrowFrame:SetPoint("CENTER", arrowFrame:GetParent(), "CENTER", 0, SweepyBoop.db.profile.nameplatesFriendly.classIconOffset);
         end
 
-        -- If we enabled icon style, or in case of a special class such as "PET", "HEALER", use icon style
-        if ( SweepyBoop.db.profile.nameplatesFriendly.classIconStyle == addon.CLASS_ICON_STYLE.ICON ) or specialClasses[class] then
-            classIconContainer.style = addon.CLASS_ICON_STYLE.ICON;
-        else
-            classIconContainer.style = addon.CLASS_ICON_STYLE.ARROW;
-        end
-
-        classIconContainer.currentGUID = unitGUID;
+        classIconContainer.class = class;
         classIconContainer.pvpClassification = pvpClassification;
+        classIconContainer.roleAssigned = roleAssigned;
         classIconContainer.lastModifiedFriendly = lastModifiedFriendly;
     end
 
-    addon.UpdateTargetHighlight(nameplate, frame);
+    addon.UpdateClassIconTargetHighlight(nameplate, frame);
 end

--- a/Nameplates/ClassIcons.lua
+++ b/Nameplates/ClassIcons.lua
@@ -38,13 +38,11 @@ local function GetIconOptions(class, pvpClassification, roleAssigned)
     iconCoords = CLASS_ICON_TCOORDS[class];
 
     if ( roleAssigned == "HEALER" ) and config.useHealerIcon then
-        if config.showHealerOnly then -- can be overwritten by flag carrier
-            iconID = nil;
-        else
-            iconID = addon.ICON_ID_HEALER;
-            iconCoords = addon.ICON_COORDS_HEALER;
-            scaleFactor = specialIconScaleFactor;
-        end
+        iconID = addon.ICON_ID_HEALER;
+        iconCoords = addon.ICON_COORDS_HEALER;
+        scaleFactor = specialIconScaleFactor;
+    elseif ( roleAssigned ~= "HEALER" ) and config.showHealerOnly then
+        iconID = nil;
     end
 
     if ( flagCarrierIcons[pvpClassification] ) and config.useFlagCarrierIcon then

--- a/Nameplates/ClassIcons.lua
+++ b/Nameplates/ClassIcons.lua
@@ -61,13 +61,10 @@ addon.UpdateClassIconTargetHighlight = function (nameplate, frame)
 end
 
 -- For FC icon, listen to whatever triggers CompactUnitFrame_UpdatePvPClassificationIndicator
-addon.UpdateClassIcon = function(nameplate, frame, forceUpdate)
+addon.UpdateClassIcon = function(nameplate, frame)
     if ( not nameplate.classIconContainer ) then return end
     local classIconContainer = nameplate.classIconContainer;
     if ( not classIconContainer.FriendlyClassIcon ) or ( not classIconContainer.FriendlyClassArrow ) then return end
-
-    -- Only update if visible or forceUpdate (on first show)
-    if ( not classIconContainer.isShown ) and ( not forceUpdate ) then return end
 
     -- Full update if class, PvPClassification, roleAssigned or configurations have changed
     -- (healer icons work between solo shuffle rounds because UnitGroupRolesAssigned works on opponent healer as well)
@@ -118,7 +115,7 @@ end
 
 addon.ShowClassIcon = function (nameplate, frame)
     EnsureClassIcon(nameplate);
-    addon.UpdateClassIcon(nameplate, frame, true);
+    addon.UpdateClassIcon(nameplate, frame);
     if ( not nameplate.classIconContainer ) then return end
     local classIconContainer = nameplate.classIconContainer;
 

--- a/Nameplates/NameplateFilter.lua
+++ b/Nameplates/NameplateFilter.lua
@@ -58,7 +58,19 @@ local function EnsureNpcHighlight(frame)
     return frame.npcHighlight;
 end
 
+addon.UpdateNpcHighlight = function(frame)
+    -- Parented to UnitFrame to inherit the visibility
+    local highlight = EnsureNpcHighlight(frame);
+    local unitGUID = UnitGUID(frame.unit);
+    if ( highlight.currentGuid ~= unitGUID ) then
+        local npcID = select(6, strsplit("-", unitGUID));
+        highlight.customIcon:SetTexture(addon.iconTexture[npcID]); -- nil if no texture found
+        highlight.currentGuid = unitGUID;
+    end
+end
+
 addon.ShowNpcHighlight = function(frame)
+    addon.UpdateNpcHighlight(frame);
     local highlight = frame.npcHighlight;
 
     if highlight then
@@ -76,16 +88,5 @@ addon.HideNpcHighlight = function(frame)
         highlight.glowTexture:Hide();
         highlight.customIcon:Hide();
         highlight:Hide();
-    end
-end
-
-addon.UpdateNpcHighlight = function(frame)
-    -- Parented to UnitFrame to inherit the visibility
-    local highlight = EnsureNpcHighlight(frame);
-    local unitGUID = UnitGUID(frame.unit);
-    if ( highlight.currentGuid ~= unitGUID ) then
-        local npcID = select(6, strsplit("-", unitGUID));
-        highlight.customIcon:SetTexture(addon.iconTexture[npcID]); -- nil if no texture found
-        highlight.currentGuid = unitGUID;
     end
 end

--- a/Nameplates/Nameplates.lua
+++ b/Nameplates/Nameplates.lua
@@ -109,7 +109,6 @@ end
 function SweepyBoop:SetupNameplateModules()
     local eventFrame = CreateFrame("Frame");
     eventFrame:RegisterEvent(addon.NAME_PLATE_UNIT_ADDED);
-    eventFrame:RegisterEvent(addon.NAME_PLATE_UNIT_REMOVED);
     eventFrame:RegisterEvent(addon.UPDATE_BATTLEFIELD_SCORE);
     eventFrame:RegisterEvent(addon.UNIT_FACTION);
     eventFrame:SetScript("OnEvent", function (_, event, unitId)
@@ -124,15 +123,10 @@ function SweepyBoop:SetupNameplateModules()
                 else
                     UpdateWidgets(nameplate, nameplate.UnitFrame);
                 end
-            end
-        elseif event == addon.NAME_PLATE_UNIT_REMOVED then
-            local nameplate = C_NamePlate.GetNamePlateForUnit(unitId);
-            if nameplate and nameplate.UnitFrame then
-                if nameplate.UnitFrame:IsForbidden() then return end
-                nameplate.UnitFrame.isNameplateUnitFrame = true;
-                HideWidgets(nameplate, nameplate.UnitFrame);
+                print("NAME_PLATE_UNIT_ADDED", nameplate.UnitFrame.unit);
             end
         elseif event == addon.UPDATE_BATTLEFIELD_SCORE then -- This cannot be triggered in restricted areas
+            if ( not C_PvP.IsBattleground() ) then return end -- Only needed in battlegrounds for updating visible spec icons
             local nameplates = C_NamePlate.GetNamePlates();
             for i = 1, #(nameplates) do
                 local nameplate = nameplates[i];
@@ -152,6 +146,7 @@ function SweepyBoop:SetupNameplateModules()
                 if ( not IsRestricted()) then
                     UpdateWidgets(nameplate, nameplate.UnitFrame);
                 end
+                print("UNIT_FACTION", nameplate.UnitFrame.unit);
             end
         end
     end)
@@ -165,6 +160,7 @@ function SweepyBoop:SetupNameplateModules()
             -- Otherwise we can't guarantee the order of events CompactUnitFrame_UpdateClassificationIndicator and CompactUnitFrame_UpdateName
             -- Consequently we can't guarantee the target highlight is up-to-date on FC
             addon.UpdateClassIcon(frame:GetParent(), frame);
+            print("CompactUnitFrame_UpdatePvPClassificationIndicator", frame.unit);
         end
     end)
 

--- a/Nameplates/Nameplates.lua
+++ b/Nameplates/Nameplates.lua
@@ -148,6 +148,7 @@ function SweepyBoop:SetupNameplateModules()
                     local currentGuid = UnitGUID(unitId);
                     local currentHostilility = addon.UnitIsHostile(unitId);
                     -- If nameplate's displayed GUID did not change but hostility did, update widgets
+                    -- This should prevent most of the redundant UpdateWidgets calls
                     if nameplate.currentGUID == currentGuid and nameplate.currentHostility ~= currentHostilility then
                         UpdateWidgets(nameplate, nameplate.UnitFrame);
                         nameplate.currentHostility = currentHostilility;

--- a/Nameplates/Nameplates.lua
+++ b/Nameplates/Nameplates.lua
@@ -2,6 +2,7 @@ local _, addon = ...;
 
 local function HideWidgets(nameplate, frame)
     addon.HideClassIcon(nameplate);
+    addon.HidePetIcon(nameplate);
     addon.HideNpcHighlight(frame);
     addon.HideSpecIcon(frame);
 end

--- a/Nameplates/Nameplates.lua
+++ b/Nameplates/Nameplates.lua
@@ -118,12 +118,12 @@ function SweepyBoop:SetupNameplateModules()
             if nameplate and nameplate.UnitFrame then
                 if nameplate.UnitFrame:IsForbidden() then return end
                 nameplate.UnitFrame.isNameplateUnitFrame = true;
-                HideWidgets(nameplate, nameplate.UnitFrame); -- Hide previous widgets and do update first
+                HideWidgets(nameplate, nameplate.UnitFrame); -- Hide previous widgets (even in restricted areas)
                 if IsRestricted() then
                     UpdateUnitFrameVisibility(nameplate.UnitFrame, true); -- We don't want to hide the unit frame inside dungeons
-                    return;
-                end -- Cannot show widgets in restricted areas
-                UpdateWidgets(nameplate, nameplate.UnitFrame);
+                else
+                    UpdateWidgets(nameplate, nameplate.UnitFrame);
+                end
             end
         elseif event == addon.NAME_PLATE_UNIT_REMOVED then
             local nameplate = C_NamePlate.GetNamePlateForUnit(unitId);
@@ -139,7 +139,9 @@ function SweepyBoop:SetupNameplateModules()
                 if nameplate and nameplate.UnitFrame then
                     if nameplate.UnitFrame:IsForbidden() then return end
                     nameplate.UnitFrame.isNameplateUnitFrame = true;
-                    addon.UpdateSpecIcon(nameplate.UnitFrame);
+                    if nameplate.UnitFrame.specIconContainer and nameplate.UnitFrame.specIconContainer.isShown then
+                        addon.UpdateSpecIcon(nameplate.UnitFrame);
+                    end
                 end
             end
         elseif event == addon.UNIT_FACTION then -- This is triggered for Mind Control
@@ -147,8 +149,9 @@ function SweepyBoop:SetupNameplateModules()
             if nameplate and nameplate.UnitFrame then
                 if nameplate.UnitFrame:IsForbidden() then return end
                 nameplate.UnitFrame.isNameplateUnitFrame = true;
-                if IsRestricted() then return end
-                UpdateWidgets(nameplate, nameplate.UnitFrame);
+                if ( not IsRestricted()) then
+                    UpdateWidgets(nameplate, nameplate.UnitFrame);
+                end
             end
         end
     end)
@@ -156,8 +159,8 @@ function SweepyBoop:SetupNameplateModules()
     -- When flag is picked up / dropped
     hooksecurefunc("CompactUnitFrame_UpdatePvPClassificationIndicator", function (frame)
         -- This will only be applied to nameplates in PvP instances
-        if frame:IsForbidden() or IsRestricted() then return end
-        if frame.isNameplateUnitFrame then
+        if frame:IsForbidden() then return end
+        if frame.isNameplateUnitFrame and frame.classIconContainer and frame.classIconContainer.isShown then
             -- UpdateClassIcon should include UpdateTargetHighlight
             -- Otherwise we can't guarantee the order of events CompactUnitFrame_UpdateClassificationIndicator and CompactUnitFrame_UpdateName
             -- Consequently we can't guarantee the target highlight is up-to-date on FC

--- a/Nameplates/Nameplates.lua
+++ b/Nameplates/Nameplates.lua
@@ -40,13 +40,10 @@ local function UpdateUnitFrameVisibility(frame, show)
 end
 
 local function UpdateWidgets(nameplate, frame)
-    local hostility = addon.UnitIsHostile(frame.unit);
-
     -- Don't mess with personal resource display
     if ( UnitIsUnit(frame.unit, "player") ) then
         HideWidgets(nameplate, frame);
         UpdateUnitFrameVisibility(frame, true);
-        nameplate.currentHostility = hostility;
         return;
     end
 
@@ -90,7 +87,6 @@ local function UpdateWidgets(nameplate, frame)
 
             addon.HideNpcHighlight(frame);
             UpdateUnitFrameVisibility(frame, true); -- Always show enemy players
-            nameplate.currentHostility = hostility;
             return;
         end
 
@@ -108,8 +104,6 @@ local function UpdateWidgets(nameplate, frame)
         local isWhitelisted = ( not SweepyBoop.db.profile.nameplatesEnemy.filterEnabled ) or addon.IsNpcInWhiteList(frame.unit);
         UpdateUnitFrameVisibility(frame, isWhitelisted and ( not addon.UnitIsHunterSecondaryPet(frame.unit) ) );
     end
-
-    nameplate.currentHostility = hostility;
 end
 
 function SweepyBoop:SetupNameplateModules()
@@ -152,6 +146,7 @@ function SweepyBoop:SetupNameplateModules()
                     local hostility = addon.UnitIsHostile(unitId);
                     if nameplate.currentHostility ~= hostility then
                         UpdateWidgets(nameplate, nameplate.UnitFrame);
+                        nameplate.currentHostility = hostility;
                     end
                 end
             end

--- a/Nameplates/Nameplates.lua
+++ b/Nameplates/Nameplates.lua
@@ -17,16 +17,6 @@ local function IsRestricted()
     return restricted[instanceType];
 end
 
-local function UpdateWidgets(nameplate, frame)
-    -- Class icon mod will hide/show healthBar when showing/hiding class icons
-    addon.UpdateClassIcon(nameplate, frame);
-    addon.UpdatePetIcon(nameplate, frame);
-    -- Show enemy nameplate highlight
-    addon.UpdateNpcHighlight(frame);
-    -- Update spec icons
-    addon.UpdateSpecIcon(frame);
-end
-
 local function UpdateUnitFrameVisibility(frame, show)
     -- Force frame's child elements to not ignore parent alpha
     if ( not frame.unsetIgnoreParentAlpha ) then
@@ -48,7 +38,7 @@ local function UpdateUnitFrameVisibility(frame, show)
     frame.castBar:SetAlpha(alpha);
 end
 
-local function UpdateVisibility(nameplate, frame)
+local function UpdateWidgets(nameplate, frame)
     -- Don't mess with personal resource display
     if ( UnitIsUnit(frame.unit, "player") ) then
         HideWidgets(nameplate, frame);
@@ -65,11 +55,11 @@ local function UpdateVisibility(nameplate, frame)
             elseif UnitIsPlayer(frame.unit) then
                 -- Issue: a pet that's not one of the above 3 showed an icon
                 -- Maybe it was partypet2 and later someone else joined so this pet became partypet3
-                addon.ShowClassIcon(nameplate);
+                addon.ShowClassIcon(nameplate, frame);
                 addon.HidePetIcon(nameplate);
             elseif UnitIsUnit(frame.unit, "pet") or UnitIsUnit(frame.unit, "partypet1") or UnitIsUnit(frame.unit, "partypet2") then
                 addon.HideClassIcon(nameplate);
-                addon.ShowPetIcon(nameplate);
+                addon.ShowPetIcon(nameplate, frame);
             else
                 addon.HideClassIcon(nameplate);
                 addon.HidePetIcon(nameplate);
@@ -133,7 +123,6 @@ function SweepyBoop:SetupNameplateModules()
                     return;
                 end -- Cannot show widgets in restricted areas
                 UpdateWidgets(nameplate, nameplate.UnitFrame);
-                UpdateVisibility(nameplate, nameplate.UnitFrame);
             end
         elseif event == addon.NAME_PLATE_UNIT_REMOVED then
             local nameplate = C_NamePlate.GetNamePlateForUnit(unitId);
@@ -158,7 +147,7 @@ function SweepyBoop:SetupNameplateModules()
                 if nameplate.UnitFrame:IsForbidden() then return end
                 nameplate.UnitFrame.isNameplateUnitFrame = true;
                 if IsRestricted() then return end
-                UpdateVisibility(nameplate, nameplate.UnitFrame);
+                UpdateWidgets(nameplate, nameplate.UnitFrame);
             end
         end
     end)
@@ -206,7 +195,6 @@ function SweepyBoop:RefreshAllNamePlates()
         if nameplate and nameplate.UnitFrame then
             if nameplate.UnitFrame:IsForbidden() then return end
             UpdateWidgets(nameplate, nameplate.UnitFrame);
-            UpdateVisibility(nameplate, nameplate.UnitFrame);
         end
     end
 end

--- a/Nameplates/Nameplates.lua
+++ b/Nameplates/Nameplates.lua
@@ -40,10 +40,13 @@ local function UpdateUnitFrameVisibility(frame, show)
 end
 
 local function UpdateWidgets(nameplate, frame)
+    local hostility = addon.UnitIsHostile(frame.unit);
+
     -- Don't mess with personal resource display
     if ( UnitIsUnit(frame.unit, "player") ) then
         HideWidgets(nameplate, frame);
         UpdateUnitFrameVisibility(frame, true);
+        nameplate.currentHostility = hostility;
         return;
     end
 
@@ -87,6 +90,7 @@ local function UpdateWidgets(nameplate, frame)
 
             addon.HideNpcHighlight(frame);
             UpdateUnitFrameVisibility(frame, true); -- Always show enemy players
+            nameplate.currentHostility = hostility;
             return;
         end
 
@@ -104,6 +108,8 @@ local function UpdateWidgets(nameplate, frame)
         local isWhitelisted = ( not SweepyBoop.db.profile.nameplatesEnemy.filterEnabled ) or addon.IsNpcInWhiteList(frame.unit);
         UpdateUnitFrameVisibility(frame, isWhitelisted and ( not addon.UnitIsHunterSecondaryPet(frame.unit) ) );
     end
+
+    nameplate.currentHostility = hostility;
 end
 
 function SweepyBoop:SetupNameplateModules()
@@ -142,10 +148,12 @@ function SweepyBoop:SetupNameplateModules()
             if nameplate and nameplate.UnitFrame then
                 if nameplate.UnitFrame:IsForbidden() then return end
                 nameplate.UnitFrame.isNameplateUnitFrame = true;
-                if ( not IsRestricted()) then
-                    UpdateWidgets(nameplate, nameplate.UnitFrame);
+                if ( not IsRestricted() ) then
+                    local hostility = addon.UnitIsHostile(unitId);
+                    if nameplate.currentHostility ~= hostility then
+                        UpdateWidgets(nameplate, nameplate.UnitFrame);
+                    end
                 end
-                print("UNIT_FACTION", nameplate.UnitFrame.unit);
             end
         end
     end)
@@ -159,7 +167,6 @@ function SweepyBoop:SetupNameplateModules()
             -- Otherwise we can't guarantee the order of events CompactUnitFrame_UpdateClassificationIndicator and CompactUnitFrame_UpdateName
             -- Consequently we can't guarantee the target highlight is up-to-date on FC
             addon.UpdateClassIcon(frame:GetParent(), frame);
-            print("CompactUnitFrame_UpdatePvPClassificationIndicator", frame.unit);
         end
     end)
 

--- a/Nameplates/Nameplates.lua
+++ b/Nameplates/Nameplates.lua
@@ -170,7 +170,7 @@ function SweepyBoop:SetupNameplateModules()
         if frame:IsForbidden() then return end
 
         if frame.isNameplateUnitFrame then
-            addon.UpdateTargetHighlight(frame:GetParent(), frame);
+            addon.UpdateClassIconTargetHighlight(frame:GetParent(), frame);
 
             -- Don't update names on raid frames
             -- In BGs, flag carriers can be arena1 / arena2

--- a/Nameplates/Nameplates.lua
+++ b/Nameplates/Nameplates.lua
@@ -122,6 +122,8 @@ function SweepyBoop:SetupNameplateModules()
                     UpdateUnitFrameVisibility(nameplate.UnitFrame, true); -- We don't want to hide the unit frame inside dungeons
                 else
                     UpdateWidgets(nameplate, nameplate.UnitFrame);
+                    nameplate.currentGUID = UnitGUID(unitId);
+                    nameplate.currentHostility = addon.UnitIsHostile(unitId);
                 end
             end
         elseif event == addon.UPDATE_BATTLEFIELD_SCORE then -- This cannot be triggered in restricted areas
@@ -143,10 +145,12 @@ function SweepyBoop:SetupNameplateModules()
                 if nameplate.UnitFrame:IsForbidden() then return end
                 nameplate.UnitFrame.isNameplateUnitFrame = true;
                 if ( not IsRestricted() ) then
-                    local hostility = addon.UnitIsHostile(unitId);
-                    if nameplate.currentHostility ~= hostility then
+                    local currentGuid = UnitGUID(unitId);
+                    local currentHostilility = addon.UnitIsHostile(unitId);
+                    -- If nameplate's displayed GUID did not change but hostility did, update widgets
+                    if nameplate.currentGUID == currentGuid and nameplate.currentHostility ~= currentHostilility then
                         UpdateWidgets(nameplate, nameplate.UnitFrame);
-                        nameplate.currentHostility = hostility;
+                        nameplate.currentHostility = currentHostilility;
                     end
                 end
             end
@@ -194,6 +198,8 @@ function SweepyBoop:RefreshAllNamePlates()
         if nameplate and nameplate.UnitFrame then
             if nameplate.UnitFrame:IsForbidden() then return end
             UpdateWidgets(nameplate, nameplate.UnitFrame);
+            nameplate.currentGUID = UnitGUID(nameplate.UnitFrame.unit);
+            nameplate.currentHostility = addon.UnitIsHostile(nameplate.UnitFrame.unit);
         end
     end
 end

--- a/Nameplates/Nameplates.lua
+++ b/Nameplates/Nameplates.lua
@@ -122,8 +122,6 @@ function SweepyBoop:SetupNameplateModules()
                     UpdateUnitFrameVisibility(nameplate.UnitFrame, true); -- We don't want to hide the unit frame inside dungeons
                 else
                     UpdateWidgets(nameplate, nameplate.UnitFrame);
-                    nameplate.currentGUID = UnitGUID(unitId);
-                    nameplate.currentHostility = addon.UnitIsHostile(unitId);
                 end
             end
         elseif event == addon.UPDATE_BATTLEFIELD_SCORE then -- This cannot be triggered in restricted areas
@@ -145,14 +143,7 @@ function SweepyBoop:SetupNameplateModules()
                 if nameplate.UnitFrame:IsForbidden() then return end
                 nameplate.UnitFrame.isNameplateUnitFrame = true;
                 if ( not IsRestricted() ) then
-                    local currentGuid = UnitGUID(unitId);
-                    local currentHostilility = addon.UnitIsHostile(unitId);
-                    -- If nameplate's displayed GUID did not change but hostility did, update widgets
-                    -- This should prevent most of the redundant UpdateWidgets calls
-                    if nameplate.currentGUID == currentGuid and nameplate.currentHostility ~= currentHostilility then
-                        UpdateWidgets(nameplate, nameplate.UnitFrame);
-                        nameplate.currentHostility = currentHostilility;
-                    end
+                    UpdateWidgets(nameplate, nameplate.UnitFrame);
                 end
             end
         end
@@ -199,8 +190,6 @@ function SweepyBoop:RefreshAllNamePlates()
         if nameplate and nameplate.UnitFrame then
             if nameplate.UnitFrame:IsForbidden() then return end
             UpdateWidgets(nameplate, nameplate.UnitFrame);
-            nameplate.currentGUID = UnitGUID(nameplate.UnitFrame.unit);
-            nameplate.currentHostility = addon.UnitIsHostile(nameplate.UnitFrame.unit);
         end
     end
 end

--- a/Nameplates/Nameplates.lua
+++ b/Nameplates/Nameplates.lua
@@ -20,6 +20,7 @@ end
 local function UpdateWidgets(nameplate, frame)
     -- Class icon mod will hide/show healthBar when showing/hiding class icons
     addon.UpdateClassIcon(nameplate, frame);
+    addon.UpdatePetIcon(nameplate, frame);
     -- Show enemy nameplate highlight
     addon.UpdateNpcHighlight(frame);
     -- Update spec icons
@@ -61,10 +62,17 @@ local function UpdateVisibility(nameplate, frame)
         if configFriendly.classIconsEnabled then
             if configFriendly.hideOutsidePvP and ( not IsActiveBattlefieldArena() ) and ( not C_PvP.IsBattleground() ) then
                 addon.HideClassIcon(nameplate);
-            elseif UnitIsPlayer(frame.unit) or UnitIsUnit(frame.unit, "pet") or UnitIsUnit(frame.unit, "partypet1") or UnitIsUnit(frame.unit, "partypet2") then
+            elseif UnitIsPlayer(frame.unit) then
                 -- Issue: a pet that's not one of the above 3 showed an icon
                 -- Maybe it was partypet2 and later someone else joined so this pet became partypet3
                 addon.ShowClassIcon(nameplate);
+                addon.HidePetIcon(nameplate);
+            elseif UnitIsUnit(frame.unit, "pet") or UnitIsUnit(frame.unit, "partypet1") or UnitIsUnit(frame.unit, "partypet2") then
+                addon.HideClassIcon(nameplate);
+                addon.ShowPetIcon(nameplate);
+            else
+                addon.HideClassIcon(nameplate);
+                addon.HidePetIcon(nameplate);
             end
 
             UpdateUnitFrameVisibility(frame, false); -- if class icons are enabled, all friendly units' health bars should be hidden
@@ -77,6 +85,7 @@ local function UpdateVisibility(nameplate, frame)
         addon.HideNpcHighlight(frame);
     else
         addon.HideClassIcon(nameplate);
+        addon.HidePetIcon(nameplate);
 
         if UnitIsPlayer(frame.unit) then
             if SweepyBoop.db.profile.nameplatesEnemy.arenaSpecIconHealer or SweepyBoop.db.profile.nameplatesEnemy.arenaSpecIconOthers then
@@ -171,6 +180,7 @@ function SweepyBoop:SetupNameplateModules()
 
         if frame.isNameplateUnitFrame then
             addon.UpdateClassIconTargetHighlight(frame:GetParent(), frame);
+            addon.UpdatePetIconTargetHighlight(frame:GetParent(), frame);
 
             -- Don't update names on raid frames
             -- In BGs, flag carriers can be arena1 / arena2

--- a/Nameplates/Nameplates.lua
+++ b/Nameplates/Nameplates.lua
@@ -123,7 +123,6 @@ function SweepyBoop:SetupNameplateModules()
                 else
                     UpdateWidgets(nameplate, nameplate.UnitFrame);
                 end
-                print("NAME_PLATE_UNIT_ADDED", nameplate.UnitFrame.unit);
             end
         elseif event == addon.UPDATE_BATTLEFIELD_SCORE then -- This cannot be triggered in restricted areas
             if ( not C_PvP.IsBattleground() ) then return end -- Only needed in battlegrounds for updating visible spec icons
@@ -170,16 +169,14 @@ function SweepyBoop:SetupNameplateModules()
         if frame.isNameplateUnitFrame then
             addon.UpdateClassIconTargetHighlight(frame:GetParent(), frame);
             addon.UpdatePetIconTargetHighlight(frame:GetParent(), frame);
+        end
 
-            -- Don't update names on raid frames
-            -- In BGs, flag carriers can be arena1 / arena2
-            if IsActiveBattlefieldArena() and SweepyBoop.db.profile.nameplatesEnemy.arenaNumbersEnabled then
-                for i = 1, 3 do
-                    if UnitIsUnit(frame.unit, "arena" .. i) then
-                        frame.name:SetText(i);
-                        frame.name:SetTextColor(1,1,0); --Yellow
-                        return;
-                    end
+        if IsActiveBattlefieldArena() and frame.optionTable.showClassificationIndicator then
+            for i = 1, 3 do
+                if UnitIsUnit(frame.unit, "arena" .. i) then
+                    frame.name:SetText(i);
+                    frame.name:SetTextColor(1,1,0); --Yellow
+                    break;
                 end
             end
         end

--- a/Nameplates/PetIcons.lua
+++ b/Nameplates/PetIcons.lua
@@ -12,7 +12,20 @@ local function EnsureIcon(nameplate)
     return nameplate.FriendlyPetIcon;
 end
 
-addon.ShowPetIcon = function (nameplate)
+addon.UpdatePetIcon = function(nameplate, frame)
+    -- Only update if config changes (we have separated out pet icon from class / healer / flag carrier icons, and pet icon has fixed texture)
+    local lastModifiedFriendly = SweepyBoop.db.profile.nameplatesFriendly.lastModified;
+    local iconFrame = EnsureIcon(nameplate);
+    if ( iconFrame.lastModifiedFriendly ~= lastModifiedFriendly ) then
+        iconFrame:SetScale(SweepyBoop.db.profile.nameplatesFriendly.classIconScale / 100 * scaleFactor);
+        iconFrame.lastModifiedFriendly = lastModifiedFriendly;
+    end
+
+    addon.UpdatePetIconTargetHighlight(nameplate, frame);
+end
+
+addon.ShowPetIcon = function (nameplate, frame)
+    addon.UpdatePetIcon(nameplate, frame);
     if nameplate.FriendlyPetIcon then
         nameplate.FriendlyPetIcon:Show();
     end
@@ -28,16 +41,4 @@ addon.UpdatePetIconTargetHighlight = function (nameplate, frame)
     if nameplate.FriendlyPetIcon then
         nameplate.FriendlyPetIcon.targetHighlight:SetShown(UnitIsUnit(frame.unit, "target"));
     end
-end
-
-addon.UpdatePetIcon = function(nameplate, frame)
-    -- Only update if config changes (we have separated out pet icon from class / healer / flag carrier icons, and pet icon has fixed texture)
-    local lastModifiedFriendly = SweepyBoop.db.profile.nameplatesFriendly.lastModified;
-    local iconFrame = EnsureIcon(nameplate);
-    if ( iconFrame.lastModifiedFriendly ~= lastModifiedFriendly ) then
-        iconFrame:SetScale(SweepyBoop.db.profile.nameplatesFriendly.classIconScale / 100 * scaleFactor);
-        iconFrame.lastModifiedFriendly = lastModifiedFriendly;
-    end
-
-    addon.UpdatePetIconTargetHighlight(nameplate, frame);
 end

--- a/Nameplates/PetIcons.lua
+++ b/Nameplates/PetIcons.lua
@@ -1,0 +1,43 @@
+local _, addon = ...;
+
+local scaleFactor = 0.75; -- Smaller icons for pets
+
+local function EnsureIcon(nameplate)
+    if ( not nameplate.FriendlyPetIcon ) then
+        nameplate.FriendlyPetIcon = addon.CreateClassOrSpecIcon(nameplate, "CENTER", "CENTER", true);
+        nameplate.FriendlyPetIcon.icon:SetTexture(addon.ICON_ID_PET);
+        nameplate.FriendlyPetIcon:Hide();
+    end
+
+    return nameplate.FriendlyPetIcon;
+end
+
+addon.ShowPetIcon = function (nameplate)
+    if nameplate.FriendlyPetIcon then
+        nameplate.FriendlyPetIcon:Show();
+    end
+end
+
+addon.HidePetIcon = function(nameplate)
+    if nameplate.FriendlyPetIcon then
+        nameplate.FriendlyPetIcon:Hide();
+    end
+end
+
+addon.UpdatePetTargetHighlight = function (nameplate, frame)
+    if nameplate.FriendlyPetIcon then
+        nameplate.FriendlyPetIcon.targetHighlight:SetShown(UnitIsUnit(frame.unit, "target"));
+    end
+end
+
+addon.UpdatePetIcon = function(nameplate, frame)
+    -- Only update if config changes (we have separated out pet icon from class / healer / flag carrier icons, and pet icon has fixed texture)
+    local lastModifiedFriendly = SweepyBoop.db.profile.nameplatesFriendly.lastModified;
+    local iconFrame = EnsureIcon(nameplate);
+    if ( iconFrame.lastModifiedFriendly ~= lastModifiedFriendly ) then
+        iconFrame:SetScale(SweepyBoop.db.profile.nameplatesFriendly.iconScale / 100 * scaleFactor);
+        iconFrame.lastModifiedFriendly = lastModifiedFriendly;
+    end
+
+    addon.UpdatePetTargetHighlight(nameplate, frame);
+end

--- a/Nameplates/PetIcons.lua
+++ b/Nameplates/PetIcons.lua
@@ -20,8 +20,8 @@ end
 
 addon.UpdatePetIcon = function(nameplate, frame)
     -- Only update if config changes (we have separated out pet icon from class / healer / flag carrier icons, and pet icon has fixed texture)
-    local lastModifiedFriendly = SweepyBoop.db.profile.nameplatesFriendly.lastModified;
     local iconFrame = EnsureIcon(nameplate);
+    local lastModifiedFriendly = SweepyBoop.db.profile.nameplatesFriendly.lastModified;
     if ( iconFrame.lastModifiedFriendly ~= lastModifiedFriendly ) then
         iconFrame:SetScale(SweepyBoop.db.profile.nameplatesFriendly.classIconScale / 100 * scaleFactor);
         iconFrame.lastModifiedFriendly = lastModifiedFriendly;

--- a/Nameplates/PetIcons.lua
+++ b/Nameplates/PetIcons.lua
@@ -24,7 +24,7 @@ addon.HidePetIcon = function(nameplate)
     end
 end
 
-addon.UpdatePetTargetHighlight = function (nameplate, frame)
+addon.UpdatePetIconTargetHighlight = function (nameplate, frame)
     if nameplate.FriendlyPetIcon then
         nameplate.FriendlyPetIcon.targetHighlight:SetShown(UnitIsUnit(frame.unit, "target"));
     end
@@ -35,9 +35,9 @@ addon.UpdatePetIcon = function(nameplate, frame)
     local lastModifiedFriendly = SweepyBoop.db.profile.nameplatesFriendly.lastModified;
     local iconFrame = EnsureIcon(nameplate);
     if ( iconFrame.lastModifiedFriendly ~= lastModifiedFriendly ) then
-        iconFrame:SetScale(SweepyBoop.db.profile.nameplatesFriendly.iconScale / 100 * scaleFactor);
+        iconFrame:SetScale(SweepyBoop.db.profile.nameplatesFriendly.classIconScale / 100 * scaleFactor);
         iconFrame.lastModifiedFriendly = lastModifiedFriendly;
     end
 
-    addon.UpdatePetTargetHighlight(nameplate, frame);
+    addon.UpdatePetIconTargetHighlight(nameplate, frame);
 end

--- a/Nameplates/PetIcons.lua
+++ b/Nameplates/PetIcons.lua
@@ -12,6 +12,12 @@ local function EnsureIcon(nameplate)
     return nameplate.FriendlyPetIcon;
 end
 
+addon.UpdatePetIconTargetHighlight = function (nameplate, frame)
+    if nameplate.FriendlyPetIcon then
+        nameplate.FriendlyPetIcon.targetHighlight:SetShown(UnitIsUnit(frame.unit, "target"));
+    end
+end
+
 addon.UpdatePetIcon = function(nameplate, frame)
     -- Only update if config changes (we have separated out pet icon from class / healer / flag carrier icons, and pet icon has fixed texture)
     local lastModifiedFriendly = SweepyBoop.db.profile.nameplatesFriendly.lastModified;
@@ -34,11 +40,5 @@ end
 addon.HidePetIcon = function(nameplate)
     if nameplate.FriendlyPetIcon then
         nameplate.FriendlyPetIcon:Hide();
-    end
-end
-
-addon.UpdatePetIconTargetHighlight = function (nameplate, frame)
-    if nameplate.FriendlyPetIcon then
-        nameplate.FriendlyPetIcon.targetHighlight:SetShown(UnitIsUnit(frame.unit, "target"));
     end
 end

--- a/Nameplates/SpecIcons.lua
+++ b/Nameplates/SpecIcons.lua
@@ -47,12 +47,11 @@ local function EnsureSpecIcon(frame)
     return frame.SpecIconContainer;
 end
 
-addon.UpdateSpecIcon = function (frame, forceUpdate)
+addon.UpdateSpecIcon = function (frame)
     -- Parented to UnitFrame to inherit the visibility
     -- Only update if visible
     local specIconContainer = frame.SpecIconContainer;
     if ( not specIconContainer ) then return end
-    if ( not specIconContainer.isShown ) and ( not forceUpdate ) then return end
 
     -- Still seeing an empty icon with a red border between solo shuffle rounds
     -- Repro if play some rounds with "show healer only", then switch to "show all"?
@@ -95,7 +94,7 @@ end
 
 addon.ShowSpecIcon = function (frame)
     EnsureSpecIcon(frame);
-    addon.UpdateSpecIcon(frame, true);
+    addon.UpdateSpecIcon(frame);
     if frame.SpecIconContainer then
         for alignment, iconFrame in pairs(frame.SpecIconContainer.frames) do
             iconFrame:SetShown(alignment == SweepyBoop.db.profile.nameplatesEnemy.arenaSpecIconAlignment);

--- a/Nameplates/SpecIcons.lua
+++ b/Nameplates/SpecIcons.lua
@@ -100,8 +100,8 @@ addon.ShowSpecIcon = function (frame)
         for alignment, iconFrame in pairs(frame.SpecIconContainer.frames) do
             iconFrame:SetShown(alignment == SweepyBoop.db.profile.nameplatesEnemy.arenaSpecIconAlignment);
         end
+        frame.SpecIconContainer.isShown = true;
     end
-    frame.SpecIconContainer.isShown = true;
 end
 
 addon.HideSpecIcon = function (frame)
@@ -109,6 +109,6 @@ addon.HideSpecIcon = function (frame)
         for _, iconFrame in pairs(frame.SpecIconContainer.frames) do
             iconFrame:Hide();
         end
+        frame.SpecIconContainer.isShown = false;
     end
-    frame.SpecIconContainer.isShown = false;
 end

--- a/Nameplates/SpecIcons.lua
+++ b/Nameplates/SpecIcons.lua
@@ -47,25 +47,9 @@ local function EnsureSpecIcon(frame)
     return frame.SpecIconContainer;
 end
 
-addon.ShowSpecIcon = function (frame)
-    if frame.SpecIconContainer then
-        for alignment, iconFrame in pairs(frame.SpecIconContainer.frames) do
-            iconFrame:SetShown(alignment == SweepyBoop.db.profile.nameplatesEnemy.arenaSpecIconAlignment);
-        end
-    end
-end
-
-addon.HideSpecIcon = function (frame)
-    if frame.SpecIconContainer then
-        for _, iconFrame in pairs(frame.SpecIconContainer.frames) do
-            iconFrame:Hide();
-        end
-    end
-end
-
 addon.UpdateSpecIcon = function (frame)
     -- Parented to UnitFrame to inherit the visibility
-    local specIconContainer = EnsureSpecIcon(frame);
+    local specIconContainer = frame.SpecIconContainer;
     if ( not specIconContainer ) then return end;
 
     -- Still seeing an empty icon with a red border between solo shuffle rounds
@@ -104,5 +88,23 @@ addon.UpdateSpecIcon = function (frame)
 
         specIconContainer.lastModified = SweepyBoop.db.profile.nameplatesEnemy.lastModified;
         specIconContainer.isHealer = isHealer;
+    end
+end
+
+addon.ShowSpecIcon = function (frame)
+    EnsureSpecIcon(frame);
+    addon.UpdateSpecIcon(frame);
+    if frame.SpecIconContainer then
+        for alignment, iconFrame in pairs(frame.SpecIconContainer.frames) do
+            iconFrame:SetShown(alignment == SweepyBoop.db.profile.nameplatesEnemy.arenaSpecIconAlignment);
+        end
+    end
+end
+
+addon.HideSpecIcon = function (frame)
+    if frame.SpecIconContainer then
+        for _, iconFrame in pairs(frame.SpecIconContainer.frames) do
+            iconFrame:Hide();
+        end
     end
 end

--- a/Nameplates/SpecIcons.lua
+++ b/Nameplates/SpecIcons.lua
@@ -49,6 +49,7 @@ end
 
 addon.UpdateSpecIcon = function (frame)
     -- Parented to UnitFrame to inherit the visibility
+    -- Only update if visible
     local specIconContainer = frame.SpecIconContainer;
     if ( not specIconContainer ) then return end;
 

--- a/Nameplates/SpecIcons.lua
+++ b/Nameplates/SpecIcons.lua
@@ -49,7 +49,6 @@ end
 
 addon.UpdateSpecIcon = function (frame)
     -- Parented to UnitFrame to inherit the visibility
-    -- Only update if visible
     local specIconContainer = frame.SpecIconContainer;
     if ( not specIconContainer ) then return end
 

--- a/Nameplates/SpecIcons.lua
+++ b/Nameplates/SpecIcons.lua
@@ -47,11 +47,12 @@ local function EnsureSpecIcon(frame)
     return frame.SpecIconContainer;
 end
 
-addon.UpdateSpecIcon = function (frame)
+addon.UpdateSpecIcon = function (frame, forceUpdate)
     -- Parented to UnitFrame to inherit the visibility
     -- Only update if visible
     local specIconContainer = frame.SpecIconContainer;
-    if ( not specIconContainer ) then return end;
+    if ( not specIconContainer ) then return end
+    if ( not specIconContainer.isShown ) and ( not forceUpdate ) then return end
 
     -- Still seeing an empty icon with a red border between solo shuffle rounds
     -- Repro if play some rounds with "show healer only", then switch to "show all"?
@@ -94,12 +95,13 @@ end
 
 addon.ShowSpecIcon = function (frame)
     EnsureSpecIcon(frame);
-    addon.UpdateSpecIcon(frame);
+    addon.UpdateSpecIcon(frame, true);
     if frame.SpecIconContainer then
         for alignment, iconFrame in pairs(frame.SpecIconContainer.frames) do
             iconFrame:SetShown(alignment == SweepyBoop.db.profile.nameplatesEnemy.arenaSpecIconAlignment);
         end
     end
+    frame.SpecIconContainer.isShown = true;
 end
 
 addon.HideSpecIcon = function (frame)
@@ -108,4 +110,5 @@ addon.HideSpecIcon = function (frame)
             iconFrame:Hide();
         end
     end
+    frame.SpecIconContainer.isShown = false;
 end

--- a/SweepyBoop.toc
+++ b/SweepyBoop.toc
@@ -28,6 +28,7 @@ Core.lua
 
 Nameplates\Helpers.lua
 Nameplates\ClassIcons.lua
+Nameplates\PetIcons.lua
 Nameplates\NameplateFilter.lua
 Nameplates\SpecIcons.lua
 Nameplates\Nameplates.lua

--- a/SweepyBoop.toc
+++ b/SweepyBoop.toc
@@ -52,19 +52,19 @@ RaidFrames\FixBlizzardRaidAggro.lua
 RaidFrames\DruidHoTHelper.lua
 
 # UI Personalization (Internal)
-Internal\LoseControl.lua
-Internal\Personalization.lua
+#Internal\LoseControl.lua
+#Internal\Personalization.lua
 Internal\HideHotKeys.lua
 
 # Misc (Internal)
-Internal\DrinkMacro.lua
+#Internal\DrinkMacro.lua
 Internal\FocusMacros.lua
-Internal\CombatIndicator.lua
-Internal\PersonalDR.lua
+#Internal\CombatIndicator.lua
+#Internal\PersonalDR.lua
 
 # Weak Auras equivalent (Internal)
 Internal\CustomAuras.xml
 Internal\CustomAuras.lua
-Internal\CustomStatusBar.lua
-Internal\RaidFrameAuras.xml
-Internal\RaidFrameAuras.lua
+#Internal\CustomStatusBar.lua
+#Internal\RaidFrameAuras.xml
+#Internal\RaidFrameAuras.lua


### PR DESCRIPTION
Separate pet icons out since it almost never changes.

Update class icon iff class / pvpClassification / roleAssigned / config changes, so we can reuse the same icon for players of the same class.