### PR TITLE
Fix aura filter

### DIFF
--- a/Nameplates/AuraFilter.lua
+++ b/Nameplates/AuraFilter.lua
@@ -330,7 +330,8 @@ addon.UpdateBuffsOverride = function(self, unit, unitAuraUpdateInfo, auraSetting
             end
         end
 
-        local largeIcon = buff.isBuff or aura.customCategory == AURA_CATEGORY.CROWD_CONTROL;
+        -- Check isEnemy, don't scale buffs on friendly units
+        local largeIcon = isEnemy and buff.isBuff or aura.customCategory == AURA_CATEGORY.CROWD_CONTROL;
         buff:SetScale(largeIcon and 1.25 or 1);
 
         CooldownFrame_Set(buff.Cooldown, aura.expirationTime - aura.duration, aura.duration, aura.duration > 0, true);

--- a/Nameplates/AuraFilter.lua
+++ b/Nameplates/AuraFilter.lua
@@ -427,5 +427,5 @@ addon.OnNamePlateAuraUpdate = function (self, unit, unitAuraUpdateInfo)
         end
     end
 
-    addon.UpdateBuffsOverride(self, unit, unitAuraUpdateInfo, auraSettings);
+    self:UpdateBuffs(unit, unitAuraUpdateInfo, auraSettings);
 end

--- a/Nameplates/AuraFilter.lua
+++ b/Nameplates/AuraFilter.lua
@@ -428,5 +428,5 @@ addon.OnNamePlateAuraUpdate = function (self, unit, unitAuraUpdateInfo)
         end
     end
 
-    self:UpdateBuffs(unit, unitAuraUpdateInfo, auraSettings);
+    addon.UpdateBuffsOverride(self, unit, unitAuraUpdateInfo, auraSettings);
 end

--- a/Nameplates/Nameplates.lua
+++ b/Nameplates/Nameplates.lua
@@ -216,7 +216,7 @@ function SweepyBoop:SetupNameplateModules()
                         end
 
                         -- Call update once after we override UpdateBuffs for the first time
-                        print("Reconciliation", nameplate.UnitFrame.unit);
+                        --print("Reconciliation", nameplate.UnitFrame.unit);
                         addon.OnNamePlateAuraUpdate(nameplate.UnitFrame.BuffFrame, nameplate.UnitFrame.unit);
                     end
                 end


### PR DESCRIPTION
Sometimes all auras are gone from an enemy nameplate.
Personal resource display icons are incorrectly scaled to 125%