### PR TITLE
Fix class icon cc display for classic

### DIFF
--- a/Nameplates/Helpers.lua
+++ b/Nameplates/Helpers.lua
@@ -58,7 +58,9 @@ addon.CreateClassOrSpecIcon = function (nameplate, point, relativePoint, isFrien
         classIconFrame.cooldownCC = CreateFrame("Cooldown", nil, classIconFrame, "CooldownFrameTemplate");
         classIconFrame.cooldownCC:SetAllPoints();
         classIconFrame.cooldownCC:SetDrawEdge(true);
-        classIconFrame.cooldownCC:SetEdgeTexture("Interface\\Cooldown\\UI-HUD-ActionBar-LoC");
+        if addon.PROJECT_MAINLINE then
+            classIconFrame.cooldownCC:SetEdgeTexture("Interface\\Cooldown\\UI-HUD-ActionBar-LoC");
+        end
         classIconFrame.cooldownCC:SetUseCircularEdge(true);
         classIconFrame.cooldownCC:SetReverse(true);
         classIconFrame.cooldownCC:SetSwipeTexture("Interface/Masks/CircleMaskScalable");


### PR DESCRIPTION
We're currently seeing an empty whitebox.
Turns out it's this line:
`classIconFrame.cooldownCC:SetEdgeTexture("Interface\\Cooldown\\UI-HUD-ActionBar-LoC");`