### PR TITLE
Fix test mode for MoP

### DIFF
--- a/ArenaFrames/ArenaCooldowns.lua
+++ b/ArenaFrames/ArenaCooldowns.lua
@@ -1003,8 +1003,9 @@ function SweepyBoop:SetupArenaCooldownTracker()
         eventFrame:RegisterEvent(addon.PLAYER_TARGET_CHANGED);
         eventFrame:SetScript("OnEvent", function (frame, event, ...)
             local config = SweepyBoop.db.profile.arenaFrames;
-            if ( event == addon.PLAYER_ENTERING_WORLD ) or ( event == addon.ARENA_PREP_OPPONENT_SPECIALIZATIONS ) or ( event == addon.PLAYER_SPECIALIZATION_CHANGED and addon.TEST_MODE ) then
+            if ( event == addon.PLAYER_ENTERING_WORLD ) or ( event == addon.ARENA_PREP_OPPONENT_SPECIALIZATIONS ) or ( event == addon.PLAYER_SPECIALIZATION_CHANGED and addon.TEST_MODE and addon.PROJECT_MAINLINE ) then
                 -- PLAYER_SPECIALIZATION_CHANGED is triggered for all players, so we only process it when TEST_MODE is on
+                -- PLAYER_SPECIALIZATION_CHANGED is triggered by Stampede in MoP, we should only process it for retail...
 
                 -- Hide the external "Toggle Test Mode" group
                 SweepyBoop:HideTestArenaCooldownTracker();

--- a/Common/UnitInfoHelpers.lua
+++ b/Common/UnitInfoHelpers.lua
@@ -111,7 +111,7 @@ addon.GetSpecForPlayerOrArena = function(unit)
             end
         else
             -- Temporary solution for MoP Classic, GetSpecialization is not yet in place (as it should)
-            return 64; -- Hard code spec ID in test (https://warcraft.wiki.gg/wiki/SpecializationID)
+            return 253; -- Hard code spec ID in test (https://warcraft.wiki.gg/wiki/SpecializationID)
         end
     else
         local arenaIndex = string.sub(unit, -1, -1);


### PR DESCRIPTION
Stampede triggers PLAYER_SPECIALIZATION_CHANGED which causes a full refresh on all icons.
Ignore PLAYER_SPECIALIZATION_CHANGED event in MoP, we are missing GetSpecialization function anyways