### PR TITLE
[Feature] Add support for ArenaLive Unitframes

### DIFF
--- a/ArenaFrames/HealerIndicator.lua
+++ b/ArenaFrames/HealerIndicator.lua
@@ -52,6 +52,8 @@ local function UpdateHealerIndicator()
         size = GladiusClassIconFramearena1 and GladiusClassIconFramearena1:GetSize();
     elseif sArena then
         size = sArenaEnemyFrame1 and sArenaEnemyFrame1.ClassIcon and sArenaEnemyFrame1.ClassIcon:GetSize();
+    elseif ArenaLiveUnitFrames then
+        size = ALUF_ArenaEnemyFramesArenaEnemyFrame1 and ALUF_ArenaEnemyFramesArenaEnemyFrame1Portrait and ALUF_ArenaEnemyFramesArenaEnemyFrame1Portrait:GetSize();
     end
     if ( not size ) then
         HideHealerIndicator();
@@ -63,6 +65,8 @@ local function UpdateHealerIndicator()
         scale = GladiusButtonFramearena1 and GladiusButtonFramearena1:GetScale();
     elseif sArena then
         scale = sArena:GetScale();
+    elseif ArenaLiveUnitFrames then
+        scale = ALUF_ArenaEnemyFrames:GetScale();
     end
     if ( not scale ) then
         HideHealerIndicator();
@@ -74,6 +78,8 @@ local function UpdateHealerIndicator()
         frame = _G["GladiusClassIconFramearena" .. healerIndex];
     elseif sArena then
         frame = _G["sArenaEnemyFrame" .. healerIndex] and _G["sArenaEnemyFrame" .. healerIndex].ClassIcon;
+    elseif ArenaLiveUnitFrames then
+        frame = _G["ALUF_ArenaEnemyFramesArenaEnemyFrame" .. healerIndex] and _G["ALUF_ArenaEnemyFramesArenaEnemyFrame" .. healerIndex .. "PortraitTexture"];
     end
     if ( not frame ) then
         HideHealerIndicator();
@@ -93,7 +99,7 @@ function SweepyBoop:SetupHealerIndicator()
     frame:RegisterEvent(addon.PLAYER_ENTERING_WORLD);
     frame:RegisterEvent(addon.ARENA_PREP_OPPONENT_SPECIALIZATIONS);
     frame:SetScript("OnEvent", function ()
-        if ( not SweepyBoop.db.profile.misc.healerIndicator ) or ( not ( Gladius or sArena ) ) then -- take away the option, always enabled
+        if ( not SweepyBoop.db.profile.misc.healerIndicator ) or ( not ( Gladius or sArena or ArenaLiveUnitFrames ) ) then -- take away the option, always enabled
             HideHealerIndicator();
             return;
         end

--- a/ArenaFrames/Options.lua
+++ b/ArenaFrames/Options.lua
@@ -24,6 +24,11 @@ function SweepyBoop:TestArena()
         if ( not frame ) or ( not frame:IsShown() ) then
             sArena:Test();
         end
+    elseif ArenaLiveUnitFrames then
+        local frame = _G["ALUF_ArenaEnemyFramesArenaEnemyFrame1"];
+        if ( not frame ) or ( not frame:IsVisible() ) then -- gets hidden via parent, IsShown doesn't account for that
+            ArenaLiveUnitFrames:Test();
+        end
     else
         -- Use Blizzard arena frames
         if ( not CompactArenaFrame:IsShown() ) then

--- a/ArenaFrames/RangeIndicators.lua
+++ b/ArenaFrames/RangeIndicators.lua
@@ -92,6 +92,11 @@ function SweepyBoop:TestRangeChecker()
         if ( not frame ) or ( not frame:IsShown() ) then
             sArena:Test();
         end
+    elseif ArenaLiveUnitFrames then
+        local frame = _G["ALUF_ArenaEnemyFramesArenaEnemyFrame1"];
+        if ( not frame ) or ( not frame:IsVisible() ) then
+            ArenaLiveUnitFrames:Test();
+        end
     else
         -- Use Blizzard arena frames
         if ( not CompactArenaFrame:IsShown() ) then

--- a/Common/Constants.lua
+++ b/Common/Constants.lua
@@ -82,7 +82,7 @@ addon.ARENA_FRAME_BARS_SUPPORTED = function()
     if addon.PROJECT_MAINLINE then
         return true;
     else
-        return GladiusEx or Gladius or sArena;
+        return GladiusEx or Gladius or sArena or ArenaLiveUnitFrames;
     end
 end
 
@@ -92,6 +92,7 @@ addon.GET_ARENA_FRAME_PREFIX = function()
             ( GladiusEx and "GladiusExButtonFramearena" )
             or ( Gladius and "GladiusButtonFramearena" )
             or ( sArena and "sArenaEnemyFrame" )
+            or ( ArenaLiveUnitFrames and "ALUF_ArenaEnemyFramesArenaEnemyFrame" )
             or "CompactArenaFrameMember";
     end
 


### PR DESCRIPTION
Adds support for [ArenaLive Unitframes for MoP Classic](https://www.curseforge.com/wow/addons/arenalive-unitframes-classic).

I was inspired by the [original MoP addon from 2013](https://www.curseforge.com/wow/addons/arenalive-unitframes) and will maintain this for as long as I'm playing the expansion.

This PR primarily adds support for arena cooldowns for those frames. The RangeIndicator and HealerIcon were also added. I'm not sure how exactly they work. I tested the RangeIndicator via it's test functionality and while big/round, it's in firm "good enough" territory for me.

Up to you whether you want those two features in, otherwise I'll remove them.
