### PR TITLE
Option for class-colored names in arena cooldown tracking icons

### DIFF
--- a/ArenaFrames/ArenaCooldowns.lua
+++ b/ArenaFrames/ArenaCooldowns.lua
@@ -153,6 +153,14 @@ local function GetIcon(iconSetID, unitID, spellID, test)
             iconPool[iconSetID][iconID].TargetHighlight:SetVertexColor(0.6745, 0.2902, 0.8392, 1); -- purple
         end
 
+        local classColorName = iconSetConfig.classColorName and ( not addon.ARENA_FRAME_BARS[iconSetID] );
+        if ( not classColorName ) or ( not iconPool[iconSetID][iconID].class ) then
+            iconPool[iconSetID][iconID].Name:SetTextColor(1, 1, 1);
+        else
+            local color = RAID_CLASS_COLORS[iconPool[iconSetID][iconID].class];
+            iconPool[iconSetID][iconID].Name:SetTextColor(color.r, color.g, color.b);
+        end
+
         addon.SetHideCountdownNumbers(iconPool[iconSetID][iconID], iconSetConfig.hideCountDownNumbers);
         iconPool[iconSetID][iconID].iconSetID = iconSetID;
         iconPool[iconSetID][iconID].isTestGroup = test;
@@ -165,6 +173,13 @@ local function GetIcon(iconSetID, unitID, spellID, test)
         local glow = GetIconGlow(iconSetID);
         iconPool[iconSetID][iconID].template = ( glow and addon.ICON_TEMPLATE.GLOW ) or addon.ICON_TEMPLATE.FLASH;
         local showName = iconSetConfig.showName and ( not addon.ARENA_FRAME_BARS[iconSetID] );
+        local classColorName = iconSetConfig.classColorName and ( not addon.ARENA_FRAME_BARS[iconSetID] );
+        if ( not classColorName ) or ( not iconPool[iconSetID][iconID].class ) then
+            iconPool[iconSetID][iconID].Name:SetTextColor(1, 1, 1);
+        else
+            local color = RAID_CLASS_COLORS[iconPool[iconSetID][iconID].class];
+            iconPool[iconSetID][iconID].Name:SetTextColor(color.r, color.g, color.b);
+        end
         iconPool[iconSetID][iconID].Name:SetShown(showName);
 
         if iconSetConfig.hideBorder then

--- a/ArenaFrames/CooldownTrackingTemplates.lua
+++ b/ArenaFrames/CooldownTrackingTemplates.lua
@@ -75,6 +75,7 @@ addon.CreateCooldownTrackingIcon = function (unit, spellID, size, showName)
     -- Fill in static info here
     frame.spellInfo = spell;
     frame.priority = spell.priority;
+    frame.class = spell.class;
 
     frame.Icon:SetTexture(addon.GetSpellTexture(spellID));
     frame.Icon:SetAllPoints();

--- a/ArenaFrames/Options.lua
+++ b/ArenaFrames/Options.lua
@@ -691,34 +691,44 @@ addon.GetArenaFrameOptions = function(order)
                             name = "Show name",
                         },
 
-                        breaker4 = {
+                        classColorName = {
                             order = 15,
+                            type = "toggle",
+                            width = 1,
+                            name = "Class-colored name",
+                            hidden = function()
+                                return ( not SweepyBoop.db.profile.arenaFrames.standaloneBars[groupName].showName );
+                            end
+                        },
+
+                        breaker4 = {
+                            order = 16,
                             type = "description",
                             name = "",
                         },
 
                         hideBorder = {
-                            order = 16,
+                            order = 17,
                             type = "toggle",
                             width = 0.75,
                             name = "Hide border",
                         },
 
                         showTargetHighlight = {
-                            order = 17,
+                            order = 18,
                             type = "toggle",
                             width = 0.75,
                             name = "Highlight target",
                         },
 
                         breaker5 = {
-                            order = 18,
+                            order = 19,
                             type = "description",
                             name = "",
                         },
 
                         showUnusedIcons = {
-                            order = 19,
+                            order = 20,
                             type = "toggle",
                             name = "Show off-CD icons",
                             width = 0.9,
@@ -726,7 +736,7 @@ addon.GetArenaFrameOptions = function(order)
                         },
 
                         unusedIconAlpha = {
-                            order = 20,
+                            order = 21,
                             type = "range",
                             width = 0.8,
                             isPercent = true,
@@ -740,7 +750,7 @@ addon.GetArenaFrameOptions = function(order)
                         },
 
                         usedIconAlpha = {
-                            order = 21,
+                            order = 22,
                             type = "range",
                             width = 0.8,
                             isPercent = true,


### PR DESCRIPTION
<img width="497" height="213" alt="image" src="https://github.com/user-attachments/assets/2d8f9792-c6e9-4b36-95af-7ce80c326132" />
