### PR TITLE
RESOLVED fix: correct spell id for heroic leap mop

### DIFF
--- a/Common/SpellData_MoP.lua
+++ b/Common/SpellData_MoP.lua
@@ -1946,7 +1946,7 @@ addon.SpellData = {
         baseline = true,
     },
     -- Heroic Leap
-    [6544] = {
+    [52174] = {
         class = addon.WARRIOR,
         category = category.OTHERS,
         cooldown = 45,


### PR DESCRIPTION
Hi,

Heroic Leap spell id was incorrect for mop. Here is the fix for it: