### PR TITLE
fix: correct spell id for ring with PoM

### DIFF
--- a/Common/SpellData_MoP.lua
+++ b/Common/SpellData_MoP.lua
@@ -807,7 +807,13 @@ addon.SpellData = {
         class = addon.MAGE,
         category = category.CROWDCONTROL,
         cooldown = 45,
+        trackEvent = addon.UNIT_SPELLCAST_SUCCEEDED,
     },
+        -- Ring of frost with PoM
+        [140376] = {
+            parent = 113724,
+            use_parent_icon = true,
+        },
     -- Frostjaw
     [102051] = {
         class = addon.MAGE,


### PR DESCRIPTION
Hi,

It's me again (sorry). It looks like when using PoM, ring of frost changes it's spell id. This fix helps with that and makes both hardcasted and PoM ring work.