### PR TITLE
Fix mark of the wild warning icon

### DIFF
--- a/RaidFrames/DruidHoTHelper.lua
+++ b/RaidFrames/DruidHoTHelper.lua
@@ -407,7 +407,7 @@ local function UpdateFrame(frame)
     ApplyIconScale(container);
 
     local lifebloomAura, hotAuras, hasMarkOfTheWild = ScanUnitHoTs(unit);
-    UpdateMarkWarning(frame, hasMarkOfTheWild);
+    UpdateMarkWarning(frame, ( not UnitIsPlayer(unit) ) or hasMarkOfTheWild);
     UpdateRow1(frame, lifebloomAura);
     UpdateRow2(frame, hotAuras);
 end


### PR DESCRIPTION
Should not show up on non-player units as the buff only applies to players