### PR TITLE
Add pres evoker for raid frame buff helper

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -151,9 +151,10 @@ local defaults = {
             raidFrameAggroHighlightThickness = 2,
             raidFrameAggroHighlightAlpha = 0.5,
             raidFrameAggroHighlightAnimationSpeed = 0,
-            druidHoTHelper = true,
-            druidHoTHelperScale = 1,
-            druidHoTHelperWarning = false,
+            druidBuffHelper = true,
+            healerBuffHelperScale = 1,
+            druidBuffHelperWarning = false,
+            evokerBuffHelper = true,
         },
         misc = {
             healerInCrowdControl = false,
@@ -401,7 +402,7 @@ function SweepyBoop:RefreshConfig()
         self:SetupCombatIndicator();
         self:HideTestHealerInCrowdControl();
         self:SetupHealerInCrowdControl(); -- re-sync event registration to the new profile's toggle
-        self:RefreshDruidHoTHelper(); -- re-sync the raid-buff CVar + icons to the new profile + spec
+        self:RefreshHealerBuffHelper(); -- re-sync the raid-buff CVar + icons to the new profile + spec
     end
 
     local currentTime = GetTime();

--- a/RaidFrames/BuffHelper.lua
+++ b/RaidFrames/BuffHelper.lua
@@ -236,7 +236,7 @@ local function EnsureContainer(frame)
     container.classBuffWarningIcon = CreateBuffIcon(container.frame, ROW2_BUFF_SIZE, frameLevel);
     container.classBuffWarningIcon.texture:SetDesaturated(true);
     container.classBuffWarningIcon.cooldown:Hide();
-    container.classBuffWarningIcon.fixedPixelGlow = addon.CreateFixedPixelGlow(container.classBuffWarningIcon, ROW2_BUFF_SIZE, ROW2_BUFF_SIZE, missingClassBuffGlowColor, 10);
+    container.classBuffWarningIcon.fixedPixelGlow = addon.CreateFixedPixelGlow(container.classBuffWarningIcon, ROW2_BUFF_SIZE, ROW2_BUFF_SIZE, missingClassBuffGlowColor, 10, nil, nil, 0);
     container.classBuffWarningIcon:SetPoint("RIGHT", container.primaryBuffIcon, "LEFT", -ROW2_BUFF_SPACING, 0);
 
     -- Row 2: up to four configured buffs, anchored dynamically in UpdateRow2 (packed, no gaps).

--- a/RaidFrames/BuffHelper.lua
+++ b/RaidFrames/BuffHelper.lua
@@ -1,61 +1,118 @@
 local _, addon = ...;
 
--- Resto Druid raid-frame HoT helper: draw the player's own HoTs on each raid frame as our own
--- icons, so Blizzard's default raid-frame buff icons can be turned off entirely.
+-- Raid-frame buff helper for supported healing specs: draw the player's own important buffs on each
+-- raid frame as our own icons, so Blizzard's default raid-frame buff icons can be turned off entirely.
 --
 -- Two rows per frame, anchored to the right edge (the frame center is left for Blizzard's big
 -- defensive-cooldown icon):
---   Row 1 - Mark of the Wild warning + Lifebloom. Lifebloom has cooldown swipe and glows while
---           inside its refresh (pandemic) window (the last 30% of its duration). The Mark warning
---           glows red while the unit is missing Mark of the Wild.
---   Row 2 - the four Swiftmend-consumable HoTs (Regrowth, Wild Growth, Rejuvenation, Germination):
---           icon + cooldown swipe, packed in Swiftmend-priority order with no gaps. When none of the
---           four are active we show a warning icon instead.
+--   Row 1 - class-buff warning + the spec's primary tracked buff. Resto Druid shows Lifebloom, which
+--           glows inside its refresh (pandemic) window. Preservation Evoker shows Echo without a
+--           refresh-window glow because Echo is consumed by the next heal rather than refreshed.
+--   Row 2 - four spec-specific player-applied buffs, packed in priority order with no gaps. When none
+--           of the four are active we can show a warning icon instead.
 --
 -- Retail (12.x) notes:
 --   * Blizzard's per-buff hook (CompactUnitFrame_UtilSetBuff) and the Lua buff-frame pipeline were
 --     removed, and a frame's real buff icons aren't addon-accessible. So we track each CompactUnitFrame
 --     via CompactUnitFrame_UpdateAll, map unit -> frame(s), refresh on UNIT_AURA, query the player's
---     HoTs ourselves, and draw our own icons.
+--     buffs ourselves, and draw our own icons.
 --   * Aura APIs are SecretWhenUnitAuraRestricted, so unrelated auras can come back as secret values in
---     active PvP. The helper only cares about the five player-applied HoTs below; unrelated secret auras
---     must not suppress the Row 2 warning.
+--     active PvP. The helper only cares about the configured player-applied buffs below; unrelated secret
+--     auras must not suppress the Row 2 warning.
 
 local GetAuraDataByIndex = C_UnitAuras.GetAuraDataByIndex;
 local maxAuras = 255;
-local refreshFraction = 0.3; -- glow once Lifebloom is within the last 30% of its duration
-
--- Lifebloom (Row 1). These two are mutually exclusive on a target.
-local lifeblooms = {
-    [33763] = true,  -- Lifebloom
-    [290754] = true, -- Lifebloom (Early Spring, PvP talent)
-};
+local lifebloomRefreshFraction = 0.3; -- glow once Lifebloom is within the last 30% of its duration
 
 local markOfTheWild = 1126;
-
--- The four Swiftmend-consumable HoTs (Row 2), in the order Swiftmend is believed to consume them
--- (left = consumed first).
---
--- IMPORTANT: this order is UNVERIFIED. Swiftmend's consumption priority is server-side and is NOT
--- present in Blizzard's wow-ui-source. The list below is the commonly-cited order; reorder this single
--- list once you confirm it in-game / on Wowhead and Row 2 will re-pack accordingly.
-local swiftmendPriority = {
-    8936,   -- Regrowth
-    48438,  -- Wild Growth
-    774,    -- Rejuvenation
-    155777, -- Germination (VERIFY: 155675 is the talent/passive; 155777 is the HoT aura on the target)
+local blessingOfTheBronze = 381748; -- Evoker's applied raid-buff aura; used for the warning icon
+local blessingOfTheBronzeAuras = {
+    [381732] = true, -- Death Knight
+    [381741] = true, -- Demon Hunter
+    [381746] = true, -- Druid
+    [381748] = true, -- Evoker
+    [381749] = true, -- Hunter
+    [381750] = true, -- Mage
+    [381751] = true, -- Monk
+    [381752] = true, -- Paladin
+    [381753] = true, -- Priest
+    [381754] = true, -- Rogue
+    [381756] = true, -- Shaman
+    [381757] = true, -- Warlock
+    [381758] = true, -- Warrior
 };
 
--- Lookup set built from the ordered list above so the two never drift apart.
-local swiftmendHoTs = {};
-for _, spellId in ipairs(swiftmendPriority) do
-    swiftmendHoTs[spellId] = true;
-end
+local profiles = {
+    [addon.SPECID.RESTORATION_DRUID] = {
+        class = addon.DRUID,
+        primaryBuffs = {
+            [33763] = true,  -- Lifebloom
+            [290754] = true, -- Lifebloom (Early Spring, PvP talent)
+        },
+        enabledSetting = "druidBuffHelper",
+        row2WarningSetting = "druidBuffHelperWarning",
+        primaryRefreshFraction = lifebloomRefreshFraction,
+        classBuff = markOfTheWild,
+        classBuffAuras = {
+            [markOfTheWild] = true,
+        },
+
+        -- The four Swiftmend-consumable HoTs (Row 2), least-to-most important left-to-right. For
+        -- Druid, that means the order Swiftmend is believed to consume them (left = consumed first).
+        --
+        -- IMPORTANT: this order is UNVERIFIED. Swiftmend's consumption priority is server-side and is
+        -- NOT present in Blizzard's wow-ui-source. Reorder this single list once you confirm it in-game /
+        -- on Wowhead and Row 2 will re-pack accordingly.
+        row2Priority = {
+            8936,   -- Regrowth
+            48438,  -- Wild Growth
+            774,    -- Rejuvenation
+            155777, -- Germination (VERIFY: 155675 is the talent/passive; 155777 is the HoT aura)
+        },
+        row2Auras = {
+            [8936] = 8936,
+            [48438] = 48438,
+            [774] = 774,
+            [155777] = 155777,
+        },
+    },
+
+    [addon.SPECID.PRESERVATION] = {
+        class = addon.EVOKER,
+        enabledSetting = "evokerBuffHelper",
+        primaryBuffs = {
+            [364343] = true, -- Echo
+        },
+        classBuff = blessingOfTheBronze,
+        classBuffAuras = blessingOfTheBronzeAuras,
+        -- Row 2 is least-to-most important left-to-right.
+        row2Priority = {
+            366155, -- Reversion
+            355941, -- Dream Breath HoT
+            373267, -- Lifebind
+            357170, -- Time Dilation
+        },
+        row2Auras = {
+            [366155] = 366155, -- Reversion
+            [1256577] = 366155, -- Merithra's Blessing (Reversion upgrade)
+            [355936] = 355941, -- Dream Breath cast spell, included defensively in case aura IDs drift
+            [355941] = 355941, -- Dream Breath HoT
+            [373267] = 373267, -- Lifebind periodic aura
+            [373270] = 373267, -- Lifebind dummy aura
+            [357170] = 357170, -- Time Dilation
+        },
+    },
+};
+
+local supportedClasses = {
+    [addon.DRUID] = true,
+    [addon.EVOKER] = true,
+};
 
 -- Layout (all tunable). Both rows hug the frame's right edge; the block is centered vertically.
-local LIFEBLOOM_SIZE = 20;
-local HOT_SIZE = 16;       -- 4 * 16 + 3 * HOT_SPACING fits even narrow 40-man frames
-local HOT_SPACING = 1;     -- gap between Row 2 icons
+local PRIMARY_BUFF_SIZE = 20;
+local ROW2_BUFF_SIZE = 16;       -- 4 * 16 + 3 * ROW2_BUFF_SPACING fits even narrow 40-man frames
+local ROW2_BUFF_SPACING = 1;     -- gap between Row 2 icons
 local ROW_SPACING = 2;     -- gap between Row 1 and Row 2
 local RIGHT_PAD = 2;       -- inset from the frame's right edge
 local FRAME_LEVEL_OFFSET = 10;
@@ -63,16 +120,16 @@ local ROW_CENTER_OFFSET = ROW_SPACING / 2; -- split the row gap around the raid-
 local PACK_DIRECTION = "LEFT_TO_RIGHT"; -- "LEFT_TO_RIGHT" (priority 1 leftmost) or "RIGHT_TO_LEFT"
 
 local glowColor = { 0, 1, 0, 1 }; -- green (RGBA)
-local markWarningGlowColor = { 1, 0, 0, 1 }; -- red (RGBA)
-local markOfTheWildTexture = addon.GetSpellTexture(markOfTheWild);
+local missingClassBuffGlowColor = { 1, 0, 0, 1 }; -- red (RGBA)
 local warningTexture = "Interface\\DialogFrame\\UI-Dialog-Icon-AlertNew"; -- yellow warning triangle
 
-local isDruid = ( addon.GetUnitClass("player") == addon.DRUID ); -- class is fixed for the login session
-local isRestoSpec = false; -- spec can change mid-session; refreshed on PLAYER_SPECIALIZATION_CHANGED
+local playerClass = addon.GetUnitClass("player"); -- class is fixed for the login session
+local isSupportedClass = supportedClasses[playerClass] and true or false;
+local activeProfile; -- spec can change mid-session; refreshed on PLAYER_SPECIALIZATION_CHANGED
 
 local cufPool = {};    -- frame -> true: raid/party CompactUnitFrames we've seen
 local unitFrames = {}; -- unit token -> { [frame] = true }: which frames currently show a unit
-local tracked = {};    -- frame -> { expirationTime, duration, timeMod, refreshTime }: active lifeblooms (glow timer)
+local tracked = {};    -- frame -> { expirationTime, timeMod, refreshTime }: active primary buffs with timer glows
 
 local function ShouldGlow(info, now)
     if ( info.expirationTime <= now ) then return false end
@@ -117,9 +174,9 @@ local function StyleCooldown(cooldown)
     cooldown.noCooldownCount = true; -- hide OmniCC timers
 end
 
--- A single HoT icon: texture + cooldown swipe. Each icon is its own frame so a future Soul of the
+-- A single buff icon: texture + cooldown swipe. Each icon is its own frame so a future Soul of the
 -- Forest border can be attached per icon without touching the others.
-local function CreateHoTIcon(parent, size, frameLevel, createGlow)
+local function CreateBuffIcon(parent, size, frameLevel, createGlow)
     local icon = CreateFrame("Frame", nil, parent);
     icon:SetSize(size, size);
     icon:SetFrameLevel(frameLevel);
@@ -140,7 +197,7 @@ local function CreateHoTIcon(parent, size, frameLevel, createGlow)
 end
 
 local function ApplyIconScale(container)
-    container.frame:SetScale(SweepyBoop.db.profile.raidFrames.druidHoTHelperScale or 1);
+    container.frame:SetScale(SweepyBoop.db.profile.raidFrames.healerBuffHelperScale or 1);
 end
 
 local function CreateWarningIcon(parent, size, frameLevel)
@@ -159,7 +216,7 @@ end
 -- Build (once) the per-frame container holding both rows. Retail doesn't expose a frame's real buff
 -- icons, so we draw our own.
 local function EnsureContainer(frame)
-    local container = frame.druidHoT;
+    local container = frame.healerBuffHelper;
     if container then return container end
 
     local frameLevel = frame:GetFrameLevel() + FRAME_LEVEL_OFFSET;
@@ -171,31 +228,30 @@ local function EnsureContainer(frame)
     container.frame:SetFrameLevel(frameLevel);
     container.scratch = {}; -- ordered list of the currently-active Row 2 auras
 
-    -- Row 1: Lifebloom, right edge, upper half. The bottom edge sits just above the frame center.
-    container.lifebloomIcon = CreateHoTIcon(container.frame, LIFEBLOOM_SIZE, frameLevel, true);
-    container.lifebloomIcon:SetPoint("TOPRIGHT", container.frame, "RIGHT", 0, LIFEBLOOM_SIZE + ROW_CENTER_OFFSET);
+    -- Row 1: primary buff, right edge, upper half. The bottom edge sits just above the frame center.
+    container.primaryBuffIcon = CreateBuffIcon(container.frame, PRIMARY_BUFF_SIZE, frameLevel, true);
+    container.primaryBuffIcon:SetPoint("TOPRIGHT", container.frame, "RIGHT", 0, PRIMARY_BUFF_SIZE + ROW_CENTER_OFFSET);
 
-    -- Row 1 warning: Mark of the Wild missing, same size as the smaller Row 2 icons and left of Lifebloom.
-    container.markWarningIcon = CreateHoTIcon(container.frame, HOT_SIZE, frameLevel);
-    container.markWarningIcon.texture:SetTexture(markOfTheWildTexture);
-    container.markWarningIcon.texture:SetDesaturated(true);
-    container.markWarningIcon.cooldown:Hide();
-    container.markWarningIcon.fixedPixelGlow = addon.CreateFixedPixelGlow(container.markWarningIcon, HOT_SIZE, HOT_SIZE, markWarningGlowColor, 10);
-    container.markWarningIcon:SetPoint("RIGHT", container.lifebloomIcon, "LEFT", -HOT_SPACING, 0);
+    -- Row 1 warning: missing class buff, same size as the smaller Row 2 icons and left of the primary buff.
+    container.classBuffWarningIcon = CreateBuffIcon(container.frame, ROW2_BUFF_SIZE, frameLevel);
+    container.classBuffWarningIcon.texture:SetDesaturated(true);
+    container.classBuffWarningIcon.cooldown:Hide();
+    container.classBuffWarningIcon.fixedPixelGlow = addon.CreateFixedPixelGlow(container.classBuffWarningIcon, ROW2_BUFF_SIZE, ROW2_BUFF_SIZE, missingClassBuffGlowColor, 10);
+    container.classBuffWarningIcon:SetPoint("RIGHT", container.primaryBuffIcon, "LEFT", -ROW2_BUFF_SPACING, 0);
 
-    -- Row 2: up to four Swiftmend HoTs, anchored dynamically in UpdateRow2 (packed, no gaps).
-    container.hotIcons = {};
+    -- Row 2: up to four configured buffs, anchored dynamically in UpdateRow2 (packed, no gaps).
+    container.row2Icons = {};
     for i = 1, 4 do
-        container.hotIcons[i] = CreateHoTIcon(container.frame, HOT_SIZE, frameLevel);
+        container.row2Icons[i] = CreateBuffIcon(container.frame, ROW2_BUFF_SIZE, frameLevel);
     end
 
-    -- Row 2 alternative: warning shown when none of the four HoTs are active. Sits in the first Row 2 slot.
-    container.warningIcon = CreateWarningIcon(container.frame, HOT_SIZE, frameLevel);
-    container.warningIcon:SetPoint("TOPRIGHT", container.lifebloomIcon, "BOTTOMRIGHT", 0, -ROW_SPACING);
+    -- Row 2 alternative: warning shown when none of the four buffs are active. Sits in the first Row 2 slot.
+    container.warningIcon = CreateWarningIcon(container.frame, ROW2_BUFF_SIZE, frameLevel);
+    container.warningIcon:SetPoint("TOPRIGHT", container.primaryBuffIcon, "BOTTOMRIGHT", 0, -ROW_SPACING);
 
     ApplyIconScale(container);
 
-    frame.druidHoT = container;
+    frame.healerBuffHelper = container;
     return container;
 end
 
@@ -211,23 +267,23 @@ local function SetIconCooldown(icon, aura)
 end
 
 local function ClearFrame(frame)
-    local container = frame.druidHoT;
+    local container = frame.healerBuffHelper;
     if container then
-        SetIconGlow(container.lifebloomIcon, false);
-        container.lifebloomIcon:Hide();
-        for i = 1, #container.hotIcons do
-            container.hotIcons[i]:Hide();
+        SetIconGlow(container.primaryBuffIcon, false);
+        container.primaryBuffIcon:Hide();
+        for i = 1, #container.row2Icons do
+            container.row2Icons[i]:Hide();
         end
-        SetPixelGlow(container.markWarningIcon, false);
-        container.markWarningIcon:Hide();
+        SetPixelGlow(container.classBuffWarningIcon, false);
+        container.classBuffWarningIcon:Hide();
         container.warningIcon:Hide();
     end
     tracked[frame] = nil;
 end
 
--- Throttled loop: UNIT_AURA only fires when an aura changes, but the Lifebloom refresh window is
--- time-based, so we re-evaluate its glow on a timer while any Lifebloom is active. Row 2 needs no timer
--- (the Cooldown widget animates its own swipe and aura gain/loss/expiry all fire UNIT_AURA).
+-- Throttled loop: UNIT_AURA only fires when an aura changes, but a primary buff's refresh window can be
+-- time-based, so we re-evaluate its glow on a timer while any timer-glow primary buff is active. Row 2
+-- needs no timer (the Cooldown widget animates its own swipe and aura gain/loss/expiry all fire UNIT_AURA).
 local updater = CreateFrame("Frame");
 updater.elapsed = 0;
 updater:Hide();
@@ -244,63 +300,67 @@ updater:SetScript("OnUpdate", function (self, elapsed)
     local now = GetTime();
     for frame, info in pairs(tracked) do
         if ( info.expirationTime <= now ) then
-            -- Lifebloom expired. UNIT_AURA will also fire, but stop the glow on time and only touch
-            -- Row 1 here (Row 2's HoTs are independent and may still be active).
-            local container = frame.druidHoT;
+            -- The primary buff expired. UNIT_AURA will also fire, but stop the glow on time and only
+            -- touch Row 1 here (Row 2's buffs are independent and may still be active).
+            local container = frame.healerBuffHelper;
             if container then
-                SetIconGlow(container.lifebloomIcon, false);
-                container.lifebloomIcon:Hide();
+                SetIconGlow(container.primaryBuffIcon, false);
+                container.primaryBuffIcon:Hide();
             end
             tracked[frame] = nil;
-        elseif frame.druidHoT then
-            SetIconGlow(frame.druidHoT.lifebloomIcon, ShouldGlow(info, now));
+        elseif frame.healerBuffHelper then
+            SetIconGlow(frame.healerBuffHelper.primaryBuffIcon, ShouldGlow(info, now));
         end
     end
 end)
 
--- One pass over the player's helpful auras on a unit. We only track five HoTs by spellId; a secret
--- spellId (PvP-restricted) can't match any of them, so skip it rather than suppress the warning.
-local scanHoTs = {}; -- per-unit scan scratch; returned data is consumed synchronously before the next wipe
-local function ScanUnitHoTs(unit)
-    wipe(scanHoTs);
-    local lifebloomAura;
-    local hasMarkOfTheWild = false;
+-- One pass over the helpful auras on a unit. Secret PvP-restricted spell IDs cannot match any configured
+-- aura, so skip them rather than suppressing the Row 2 warning.
+local scanAuras = {}; -- per-unit scan scratch; returned data is consumed synchronously before the next wipe
+local function ScanUnitAuras(unit, profile)
+    wipe(scanAuras);
+    local primaryAura;
+    local hasClassBuff = false;
     for i = 1, maxAuras do
         local aura = GetAuraDataByIndex(unit, i, "HELPFUL");
         if ( not aura ) then break end
         local spellId = aura.spellId;
-        if ( not addon.IsSecretValue(spellId) ) then -- a secret spellId matches none of our tracked HoTs
-            if ( spellId == markOfTheWild ) then
-                hasMarkOfTheWild = true;
-            else
-                local sourceUnit = aura.sourceUnit;
-                if ( not addon.IsSecretValue(sourceUnit) ) and ( sourceUnit == "player" ) then
-                    if lifeblooms[spellId] then
-                        lifebloomAura = aura;
-                    elseif swiftmendHoTs[spellId] then
-                        scanHoTs[spellId] = aura;
+        if ( not addon.IsSecretValue(spellId) ) then
+            if profile.classBuffAuras[spellId] then
+                hasClassBuff = true;
+            end
+
+            local sourceUnit = aura.sourceUnit;
+            if ( not addon.IsSecretValue(sourceUnit) ) and ( sourceUnit == "player" ) then
+                if profile.primaryBuffs[spellId] then
+                    primaryAura = aura;
+                else
+                    local row2SpellId = profile.row2Auras[spellId];
+                    if row2SpellId and ( ( spellId == row2SpellId ) or ( not scanAuras[row2SpellId] ) ) then
+                        scanAuras[row2SpellId] = aura;
                     end
                 end
             end
         end
     end
-    return lifebloomAura, scanHoTs, hasMarkOfTheWild;
+    return primaryAura, scanAuras, hasClassBuff;
 end
 
-local function UpdateMarkWarning(frame, hasMarkOfTheWild)
-    local icon = frame.druidHoT.markWarningIcon;
-    if hasMarkOfTheWild then
+local function UpdateClassBuffWarning(frame, profile, hasClassBuff)
+    local icon = frame.healerBuffHelper.classBuffWarningIcon;
+    if hasClassBuff then
         SetPixelGlow(icon, false);
         icon:Hide();
         return;
     end
 
+    icon.texture:SetTexture(addon.GetSpellTexture(profile.classBuff));
     SetPixelGlow(icon, true);
     icon:Show();
 end
 
-local function UpdateRow1(frame, aura)
-    local icon = frame.druidHoT.lifebloomIcon;
+local function UpdateRow1(frame, aura, profile)
+    local icon = frame.healerBuffHelper.primaryBuffIcon;
     if ( not aura ) then
         SetIconGlow(icon, false);
         icon:Hide();
@@ -310,31 +370,41 @@ local function UpdateRow1(frame, aura)
 
     icon.texture:SetTexture(aura.icon);
     SetIconCooldown(icon, aura);
+    icon:Show();
+
+    local refreshFraction = profile.primaryRefreshFraction;
+    if ( not refreshFraction ) then
+        SetIconGlow(icon, false);
+        tracked[frame] = nil;
+        return;
+    end
 
     local timeMod = aura.timeMod or 1;
     if ( timeMod <= 0 ) then timeMod = 1 end
 
     local info = tracked[frame] or {};
     info.expirationTime = aura.expirationTime or 0;
-    info.duration = aura.duration or 0;
     info.timeMod = timeMod;
-    info.refreshTime = info.duration * refreshFraction;
+    info.refreshTime = ( aura.duration or 0 ) * refreshFraction;
     tracked[frame] = info;
 
-    icon:Show();
     SetIconGlow(icon, ShouldGlow(info, GetTime()));
     updater:Show();
 end
 
-local function UpdateRow2(frame, hotAuras)
-    local container = frame.druidHoT;
-    local icons = container.hotIcons;
+local function IsProfileEnabled(profile)
+    return SweepyBoop.db.profile.raidFrames[profile.enabledSetting] and true or false;
+end
 
-    -- Collect the active HoTs in Swiftmend-priority order.
+local function UpdateRow2(frame, row2Auras, profile)
+    local container = frame.healerBuffHelper;
+    local icons = container.row2Icons;
+
+    -- Collect the active buffs in profile display order: least important leftmost, most important rightmost.
     local present = container.scratch;
     wipe(present);
-    for _, spellId in ipairs(swiftmendPriority) do
-        local aura = hotAuras[spellId];
+    for _, spellId in ipairs(profile.row2Priority) do
+        local aura = row2Auras[spellId];
         if aura then
             present[#present + 1] = aura;
         end
@@ -346,8 +416,9 @@ local function UpdateRow2(frame, hotAuras)
         for i = 1, #icons do
             icons[i]:Hide();
         end
-        if SweepyBoop.db.profile.raidFrames.druidHoTHelperWarning then
-            container.warningIcon:Show(); -- none of the four Swiftmend HoTs are up
+        local warningSetting = profile.row2WarningSetting;
+        if warningSetting and SweepyBoop.db.profile.raidFrames[warningSetting] then
+            container.warningIcon:Show(); -- none of the configured Row 2 buffs are up
         else
             container.warningIcon:Hide();
         end
@@ -356,9 +427,9 @@ local function UpdateRow2(frame, hotAuras)
 
     container.warningIcon:Hide();
 
-    -- Lay the active icons out right-aligned under Lifebloom, chaining each to the left of the previous
-    -- one (icons[1] is the rightmost slot). Assign auras so priority 1 ends up on the correct side per
-    -- PACK_DIRECTION.
+    -- Lay the active icons out right-aligned under the primary buff, chaining each to the left of the
+    -- previous one (icons[1] is the rightmost slot). Assign auras so priority 1 ends up on the correct
+    -- side per PACK_DIRECTION.
     for i = 1, count do
         local aura;
         if ( PACK_DIRECTION == "RIGHT_TO_LEFT" ) then
@@ -373,9 +444,9 @@ local function UpdateRow2(frame, hotAuras)
 
         icon:ClearAllPoints();
         if ( i == 1 ) then
-            icon:SetPoint("TOPRIGHT", container.lifebloomIcon, "BOTTOMRIGHT", 0, -ROW_SPACING);
+            icon:SetPoint("TOPRIGHT", container.primaryBuffIcon, "BOTTOMRIGHT", 0, -ROW_SPACING);
         else
-            icon:SetPoint("TOPRIGHT", icons[i - 1], "TOPLEFT", -HOT_SPACING, 0);
+            icon:SetPoint("TOPRIGHT", icons[i - 1], "TOPLEFT", -ROW2_BUFF_SPACING, 0);
         end
         icon:Show();
     end
@@ -402,15 +473,16 @@ local function UpdateFrame(frame)
     if frame:IsForbidden() then return end
 
     local unit = frame.displayedUnit or frame.unit;
-    if ( not SweepyBoop.db.profile.raidFrames.druidHoTHelper )
-            or ( not isRestoSpec )
+    local profile = activeProfile;
+    if ( not profile )
+            or ( not IsProfileEnabled(profile) )
             or ( not unit ) or ( not UnitExists(unit) )
             or ( not IsGroupUnit(unit) ) then
         ClearFrame(frame);
         return;
     end
 
-    -- Don't show the warning on dead raiders: they have no HoTs, but a persistent warning is just noise.
+    -- Don't show the warning on dead raiders: they have no tracked buffs, but a persistent warning is just noise.
     -- Check IsSecretValue first: UnitIsDeadOrGhost can be secret in rated PvP, and the `and` must not
     -- coerce a secret value to a boolean (that would error). The secret check short-circuits before `dead`.
     local dead = UnitIsDeadOrGhost(unit);
@@ -422,22 +494,22 @@ local function UpdateFrame(frame)
     local container = EnsureContainer(frame);
     ApplyIconScale(container);
 
-    local lifebloomAura, hotAuras, hasMarkOfTheWild = ScanUnitHoTs(unit);
-    UpdateMarkWarning(frame, ( not UnitIsPlayer(unit) ) or hasMarkOfTheWild);
-    UpdateRow1(frame, lifebloomAura);
-    UpdateRow2(frame, hotAuras);
+    local primaryAura, row2Auras, hasClassBuff = ScanUnitAuras(unit, profile);
+    UpdateClassBuffWarning(frame, profile, ( not UnitIsPlayer(unit) ) or hasClassBuff);
+    UpdateRow1(frame, primaryAura, profile);
+    UpdateRow2(frame, row2Auras, profile);
 end
 
 -- Maintain unit -> frame(s) so UNIT_AURA can target only the affected frames.
 local function MapFrameUnit(frame)
     local unit = frame.displayedUnit or frame.unit;
-    if ( frame.druidHoTUnit == unit ) then return end
+    if ( frame.healerBuffHelperUnit == unit ) then return end
 
-    if frame.druidHoTUnit and unitFrames[frame.druidHoTUnit] then
-        unitFrames[frame.druidHoTUnit][frame] = nil;
+    if frame.healerBuffHelperUnit and unitFrames[frame.healerBuffHelperUnit] then
+        unitFrames[frame.healerBuffHelperUnit][frame] = nil;
     end
 
-    frame.druidHoTUnit = unit;
+    frame.healerBuffHelperUnit = unit;
     if unit then
         unitFrames[unit] = unitFrames[unit] or {};
         unitFrames[unit][frame] = true;
@@ -452,15 +524,21 @@ end
 
 local function UntrackFrame(frame)
     cufPool[frame] = nil;
-    if frame.druidHoTUnit and unitFrames[frame.druidHoTUnit] then
-        unitFrames[frame.druidHoTUnit][frame] = nil;
+    if frame.healerBuffHelperUnit and unitFrames[frame.healerBuffHelperUnit] then
+        unitFrames[frame.healerBuffHelperUnit][frame] = nil;
     end
-    frame.druidHoTUnit = nil;
+    frame.healerBuffHelperUnit = nil;
     ClearFrame(frame);
 end
 
 local function CheckSpec()
-    isRestoSpec = ( addon.GetSpecForPlayerOrArena("player") == addon.SPECID.RESTORATION_DRUID );
+    local specID = addon.GetSpecForPlayerOrArena("player");
+    local profile = profiles[specID];
+    if profile and ( profile.class == playerClass ) then
+        activeProfile = profile;
+    else
+        activeProfile = nil;
+    end
 end
 
 local function RefreshAllFrames()
@@ -503,16 +581,16 @@ end
 
 local eventFrame = CreateFrame("Frame");
 
--- Hide Blizzard's own raid-frame buffs while the helper is enabled on a Resto druid, so our icons
--- replace them. In retail 12.x a frame's individual buff icons are forbidden/secret, so the only lever
--- is the global raidFramesDisplayBuffs CVar (all-or-nothing: it hides every buff on raid frames;
+-- Hide Blizzard's own raid-frame buffs while the helper is enabled on a supported healing spec, so our
+-- icons replace them. In retail 12.x a frame's individual buff icons are forbidden/secret, so the only
+-- lever is the global raidFramesDisplayBuffs CVar (all-or-nothing: it hides every buff on raid frames;
 -- debuffs/dispels stay). Changing it re-runs setup on the protected raid frames, so we defer in combat.
 local function ShouldHideBlizzardBuffs()
-    return isRestoSpec and SweepyBoop.db.profile.raidFrames.druidHoTHelper and true or false;
+    return activeProfile and IsProfileEnabled(activeProfile) and true or false;
 end
 
 local function ApplyHideBlizzardBuffs()
-    if ( not isDruid ) or ( not addon.PROJECT_MAINLINE ) then return end -- druid-only, and retail-only
+    if ( not isSupportedClass ) or ( not addon.PROJECT_MAINLINE ) then return end -- retail-only supported classes
 
     if InCombatLockdown() then
         eventFrame:RegisterEvent(addon.PLAYER_REGEN_ENABLED); -- retry once combat ends
@@ -521,12 +599,12 @@ local function ApplyHideBlizzardBuffs()
 
     local desired = ShouldHideBlizzardBuffs() and "0" or "1";
     if ( GetCVar("raidFramesDisplayBuffs") ~= desired ) then
-        SetCVar("raidFramesDisplayBuffs", desired); -- 0 hides all raid-frame buffs, 1 restores the default
+        SetCVar("raidFramesDisplayBuffs", desired); -- 0 hides buffs while active, 1 restores them when disabled
     end
 end
 
 function SweepyBoop:SetupRaidFrameAuraModule()
-    if ( not isDruid ) then return end -- nothing to do for non-druids this session
+    if ( not isSupportedClass ) then return end -- nothing to do for unsupported classes this session
 
     CheckSpec();
 
@@ -556,10 +634,10 @@ function SweepyBoop:SetupRaidFrameAuraModule()
             end
         elseif ( event == addon.PLAYER_SPECIALIZATION_CHANGED ) then
             if ( unitTarget == "player" ) then
-                local wasResto = isRestoSpec;
+                local oldProfile = activeProfile;
                 CheckSpec();
-                ApplyHideBlizzardBuffs(); -- entering/leaving Resto flips whether we hide Blizzard buffs
-                if ( wasResto ~= isRestoSpec ) then
+                ApplyHideBlizzardBuffs(); -- entering/leaving a supported healer flips Blizzard buff hiding
+                if ( oldProfile ~= activeProfile ) then
                     RefreshAllFrames(); -- show or clear every frame for the new spec
                 end
             end
@@ -581,9 +659,9 @@ function SweepyBoop:SetupRaidFrameAuraModule()
     ApplyHideBlizzardBuffs(); -- enforce the buff-hiding CVar for the current spec + toggle
 end
 
--- Called when the Druid HoT helper toggle changes (and on profile switch): re-evaluate the buff-hiding
--- CVar and repaint every tracked frame for the new setting.
-function SweepyBoop:RefreshDruidHoTHelper()
+-- Called when the Healer Buff Helper settings change (and on profile switch): re-evaluate the
+-- buff-hiding CVar and repaint every tracked frame for the new setting.
+function SweepyBoop:RefreshHealerBuffHelper()
     ApplyHideBlizzardBuffs();
     RefreshAllFrames();
 end

--- a/RaidFrames/Options.lua
+++ b/RaidFrames/Options.lua
@@ -35,56 +35,95 @@ addon.GetRaidFrameOptions = function(order)
             header2 = {
                 order = 6,
                 type = "header",
-                name = "Druid HoT Helper",
+                name = "Healer Buff Helper",
             },
 
-            druidHoTHelper = {
+            healerBuffHelperScale = {
                 order = 7,
-                width = "full",
-                type = "toggle",
-                name = addon.FORMAT_TEXTURE(addon.ICON_PATH("spell_nature_healingtouch")) .. "Enabled",
-                desc = function ()
-                    return table.concat({
-                        "For Restoration Druids \226\128\148 replace Blizzard's raid-frame buffs with your own HoTs:",
-                        "",
-                        "\226\128\162 " .. SpellIcon(1126) .. " Mark of the Wild: red-glowing warning shown left of Lifebloom when missing.",
-                        "\226\128\162 Scale: adjust all helper icons together from 50% to 250%.",
-                        "\226\128\162 " .. SpellIcon(33763) .. " Lifebloom: its own row; glows during the refresh (pandemic) window.",
-                        "\226\128\162 Second row, packed left-to-right in " .. SpellIcon(18562) .. " Swiftmend-consume order (left = consumed first): " .. SpellIcon(8936) .. " Regrowth, " .. SpellIcon(48438) .. " Wild Growth, " .. SpellIcon(774) .. " Rejuvenation, " .. SpellIcon(155777) .. " Germination.",
-                        "\226\128\162 Hides ALL raid-frame buffs while active on Resto; debuffs and dispellable debuffs are unaffected.",
-                    }, "\n");
-                end,
-                set = function(info, val)
-                    SweepyBoop.db.profile.raidFrames[info[#info]] = val;
-                    SweepyBoop:RefreshDruidHoTHelper(); -- re-apply the buff-hiding CVar + repaint frames
-                end,
-            },
-
-            druidHoTHelperScale = {
-                order = 8,
+                width = "normal",
                 type = "range",
                 isPercent = true,
                 min = 0.5,
                 max = 2.5,
                 step = 0.05,
                 name = "Icon Scale",
-                disabled = function () return not SweepyBoop.db.profile.raidFrames.druidHoTHelper; end,
+                desc = "Adjust all helper icons together from 50% to 250%.",
+                disabled = function ()
+                    local raidFrames = SweepyBoop.db.profile.raidFrames;
+                    return ( not raidFrames.druidBuffHelper ) and ( not raidFrames.evokerBuffHelper );
+                end,
                 set = function(info, val)
                     SweepyBoop.db.profile.raidFrames[info[#info]] = val;
-                    SweepyBoop:RefreshDruidHoTHelper(); -- repaint frames so the new scale applies immediately
+                    SweepyBoop:RefreshHealerBuffHelper(); -- repaint frames so the new scale applies immediately
                 end,
             },
 
-            druidHoTHelperWarning = {
-                order = 9,
+            healerBuffHelperScaleBreak = {
+                order = 7.5,
+                type = "description",
+                name = "",
                 width = "full",
+            },
+
+            druidBuffHelper = {
+                order = 8,
+                width = "normal",
                 type = "toggle",
-                name = addon.FORMAT_TEXTURE("Interface\\DialogFrame\\UI-Dialog-Icon-AlertNew") .. "Show missing-HoT warning",
-                desc = "Show the warning icon when none of the Swiftmend-consumable HoTs are active.",
-                disabled = function () return not SweepyBoop.db.profile.raidFrames.druidHoTHelper; end,
+                name = addon.FORMAT_TEXTURE(addon.ICON_PATH("spell_nature_healingtouch")) .. "Resto Druid",
+                desc = function ()
+                    return table.concat({
+                        "Enable the helper while playing Restoration Druid.",
+                        "",
+                        "\226\128\162 " .. SpellIcon(1126) .. " Mark of the Wild warning.",
+                        "\226\128\162 " .. SpellIcon(33763) .. " Lifebloom with refresh-window glow.",
+                        "\226\128\162 Row 2: " .. SpellIcon(8936) .. " Regrowth, " .. SpellIcon(48438) .. " Wild Growth, " .. SpellIcon(774) .. " Rejuvenation, " .. SpellIcon(155777) .. " Germination.",
+                        "\226\128\162 Hides ALL raid-frame buffs while active; debuffs and dispellable debuffs are unaffected.",
+                    }, "\n");
+                end,
                 set = function(info, val)
                     SweepyBoop.db.profile.raidFrames[info[#info]] = val;
-                    SweepyBoop:RefreshDruidHoTHelper(); -- repaint frames so the warning icon appears/disappears immediately
+                    SweepyBoop:RefreshHealerBuffHelper(); -- re-apply the buff-hiding CVar + repaint frames
+                end,
+            },
+
+            druidBuffHelperWarning = {
+                order = 9,
+                width = 1.4,
+                type = "toggle",
+                name = addon.FORMAT_TEXTURE("Interface\\DialogFrame\\UI-Dialog-Icon-AlertNew") .. "Missing-buff warning",
+                desc = "For Restoration Druid only: show the warning icon when none of the Swiftmend-consumable buffs are active.",
+                disabled = function () return not SweepyBoop.db.profile.raidFrames.druidBuffHelper; end,
+                set = function(info, val)
+                    SweepyBoop.db.profile.raidFrames[info[#info]] = val;
+                    SweepyBoop:RefreshHealerBuffHelper(); -- repaint frames so the warning icon appears/disappears immediately
+                end,
+            },
+
+            druidBuffHelperBreak = {
+                order = 9.5,
+                type = "description",
+                name = "",
+                width = "full",
+            },
+
+            evokerBuffHelper = {
+                order = 10,
+                width = "full",
+                type = "toggle",
+                name = addon.FORMAT_TEXTURE(addon.ICON_PATH("Classicon_evoker")) .. "Preservation Evoker",
+                desc = function ()
+                    return table.concat({
+                        "Enable the helper while playing Preservation Evoker.",
+                        "",
+                        "\226\128\162 " .. SpellIcon(381748) .. " Blessing of the Bronze warning.",
+                        "\226\128\162 " .. SpellIcon(364343) .. " Echo without a refresh-window glow.",
+                        "\226\128\162 Row 2, least-to-most important: " .. SpellIcon(366155) .. " Reversion, " .. SpellIcon(355941) .. " Dream Breath, " .. SpellIcon(373267) .. " Lifebind, " .. SpellIcon(357170) .. " Time Dilation.",
+                        "\226\128\162 Hides ALL raid-frame buffs while active; debuffs and dispellable debuffs are unaffected.",
+                    }, "\n");
+                end,
+                set = function(info, val)
+                    SweepyBoop.db.profile.raidFrames[info[#info]] = val;
+                    SweepyBoop:RefreshHealerBuffHelper(); -- re-apply the buff-hiding CVar + repaint frames
                 end,
             },
         },

--- a/SweepyBoop.toc
+++ b/SweepyBoop.toc
@@ -62,7 +62,7 @@ ArenaFrames\HealerIndicator.lua
 ArenaFrames\RangeIndicators.lua
 ArenaFrames\Options.lua
 
-RaidFrames\DruidHoTHelper.lua
+RaidFrames\BuffHelper.lua
 RaidFrames\FixBlizzardRaidAggro.lua
 RaidFrames\Options.lua
 


### PR DESCRIPTION
## Summary

Add Preservation Evoker support to the raid-frame Healer Buff Helper.

## Preservation Evoker

- Shows `Echo` as the primary tracked buff on Row 1.
- Does not apply Lifebloom-style refresh-window glow to `Echo`.
- Shows a missing `Blessing of the Bronze` warning.
- Handles all class-specific applied `Blessing of the Bronze` aura IDs to avoid false missing-buff warnings on non-Evoker teammates.
- Tracks Row 2 buffs from least-to-most important, left-to-right:
  - `Reversion`
  - `Dream Breath`
  - `Lifebind`
  - `Time Dilation`

## Other Changes

- Generalizes the old Restoration Druid HoT helper into a profile-based Healer Buff Helper.
- Keeps existing Restoration Druid behavior:
  - `Mark of the Wild` missing-buff warning.
  - `Lifebloom` with refresh-window glow.
  - Swiftmend-consumable Row 2 buffs.
  - Druid-only missing Row 2 warning toggle.
- Adds per-spec settings for `Restoration Druid` and `Preservation Evoker`.
- Adds shared icon scaling via `healerBuffHelperScale`.
- Renames user-facing settings from “HoT Helper” to “Healer Buff Helper”.
- Syncs `raidFramesDisplayBuffs` with the current spec’s helper toggle:
  - Enabled: hide Blizzard raid-frame buffs.
  - Disabled: restore Blizzard raid-frame buffs.

## Validation

- Ran diagnostics on touched Lua files.
- Ran `validate_changes`; no errors found.
